### PR TITLE
Add Doobara-styled customer and admin order email templates and dict-compat fix

### DIFF
--- a/templates/doobarashop/order_confirmation_email.html
+++ b/templates/doobarashop/order_confirmation_email.html
@@ -1,1 +1,85 @@
-<!-- TODOO Create order confirmation email template and insert the given data from the order object -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Order Confirmation</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f6f7fb;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f6f7fb;padding:20px 10px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:640px;background:#ffffff;border:1px solid #e5e7eb;border-radius:10px;overflow:hidden;">
+            <tr>
+              <td style="padding:20px 24px;background-color:#111827;color:#ffffff;">
+                <h1 style="margin:0;font-size:22px;font-weight:700;">Doobara</h1>
+                <p style="margin:6px 0 0;font-size:14px;opacity:0.92;">Order confirmation</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px;">
+                <p style="margin:0 0 10px;font-size:16px;line-height:1.5;">Hello {{ user.first_name|default:"Customer" }},</p>
+                <p style="margin:0 0 16px;font-size:15px;line-height:1.6;">Thank you for your order. We have received it and started processing it.</p>
+
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:0 0 18px;border:1px solid #e5e7eb;border-radius:8px;">
+                  <tr>
+                    <td style="padding:14px 16px;font-size:14px;line-height:1.6;">
+                      <strong>Order #{{ order.id }}</strong><br />
+                      Date: {{ order.date|date:"M d, Y - H:i" }}<br />
+                      Status: {{ order.status|title }}
+                    </td>
+                  </tr>
+                </table>
+
+                <h2 style="margin:0 0 10px;font-size:16px;color:#111827;">Items</h2>
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;margin:0 0 20px;">
+                  <tr>
+                    <th align="left" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Product</th>
+                    <th align="center" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Qty</th>
+                    <th align="right" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Unit</th>
+                    <th align="right" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Subtotal</th>
+                  </tr>
+                  {% for item in items %}
+                  <tr>
+                    <td style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">{{ item.product_name }}</td>
+                    <td align="center" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">{{ item.quantity }}</td>
+                    <td align="right" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">${{ item.price|floatformat:2 }}</td>
+                    <td align="right" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">${{ item.subtotal|floatformat:2 }}</td>
+                  </tr>
+                  {% endfor %}
+                </table>
+
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:0 0 18px;">
+                  <tr>
+                    <td style="font-size:14px;color:#4b5563;padding:4px 0;">Shipping</td>
+                    <td align="right" style="font-size:14px;color:#111827;padding:4px 0;">${{ order.shipping_price|floatformat:2 }}</td>
+                  </tr>
+                  <tr>
+                    <td style="font-size:16px;color:#111827;padding:6px 0;"><strong>Total</strong></td>
+                    <td align="right" style="font-size:16px;color:#111827;padding:6px 0;"><strong>${{ order.total|floatformat:2 }}</strong></td>
+                  </tr>
+                </table>
+
+                {% if order.address %}
+                <h2 style="margin:0 0 10px;font-size:16px;color:#111827;">Delivery address</h2>
+                <p style="margin:0 0 14px;font-size:14px;line-height:1.6;color:#374151;">
+                  {{ order.address.name }} {{ order.address.last_name }}<br />
+                  {{ order.address.street_name }}, {{ order.address.building_appartment }}<br />
+                  {{ order.address.city_town }}<br />
+                  Phone: {{ order.address.phone_number }}
+                </p>
+                {% endif %}
+
+                {% if order.note %}
+                <p style="margin:0 0 14px;font-size:14px;line-height:1.6;color:#374151;"><strong>Order note:</strong> {{ order.note }}</p>
+                {% endif %}
+
+                <p style="margin:0;font-size:13px;line-height:1.6;color:#6b7280;">If you have any questions, reply to this email and our team will be happy to help.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/templates/doobarashop/order_notification_admin.html
+++ b/templates/doobarashop/order_notification_admin.html
@@ -1,1 +1,92 @@
-<!-- TODO: Create order notification email template for admin and insert the given data from the order object -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>New Order Notification</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f4f6fa;font-family:Arial,Helvetica,sans-serif;color:#111827;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f6fa;padding:20px 10px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:680px;background:#ffffff;border:1px solid #e5e7eb;border-radius:10px;overflow:hidden;">
+            <tr>
+              <td style="padding:18px 24px;background:#0f172a;color:#ffffff;">
+                <h1 style="margin:0;font-size:21px;">Doobara Admin</h1>
+                <p style="margin:6px 0 0;font-size:14px;opacity:0.92;">New order received</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border:1px solid #e5e7eb;border-radius:8px;margin:0 0 16px;">
+                  <tr>
+                    <td style="padding:14px 16px;font-size:14px;line-height:1.65;">
+                      <strong>Order #{{ order.id }}</strong><br />
+                      Date: {{ order.date|date:"M d, Y - H:i" }}<br />
+                      Status: {{ order.status|title }}
+                    </td>
+                  </tr>
+                </table>
+
+                <h2 style="margin:0 0 10px;font-size:16px;">Customer</h2>
+                <p style="margin:0 0 14px;font-size:14px;line-height:1.6;color:#374151;">
+                  Name: {{ user.first_name }} {{ user.last_name }}<br />
+                  Username: {{ user.username }}<br />
+                  Email: {{ user.email }}
+                </p>
+
+                {% if order.address %}
+                <h2 style="margin:0 0 10px;font-size:16px;">Delivery Address</h2>
+                <p style="margin:0 0 14px;font-size:14px;line-height:1.6;color:#374151;">
+                  {{ order.address.name }} {{ order.address.last_name }}<br />
+                  {{ order.address.street_name }}, {{ order.address.building_appartment }}<br />
+                  {{ order.address.city_town }}<br />
+                  Phone: {{ order.address.phone_number }}
+                  {% if order.address.delivery_details %}<br />Details: {{ order.address.delivery_details }}{% endif %}
+                </p>
+                {% endif %}
+
+                <h2 style="margin:0 0 10px;font-size:16px;">Order Items</h2>
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;margin:0 0 16px;">
+                  <tr>
+                    <th align="left" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Product</th>
+                    <th align="center" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Qty</th>
+                    <th align="right" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Unit</th>
+                    <th align="right" style="padding:9px 8px;border-bottom:1px solid #e5e7eb;font-size:13px;color:#4b5563;">Subtotal</th>
+                  </tr>
+                  {% for item in items %}
+                  <tr>
+                    <td style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">{{ item.product_name }}</td>
+                    <td align="center" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">{{ item.quantity }}</td>
+                    <td align="right" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">${{ item.price|floatformat:2 }}</td>
+                    <td align="right" style="padding:9px 8px;border-bottom:1px solid #f1f5f9;font-size:14px;">${{ item.subtotal|floatformat:2 }}</td>
+                  </tr>
+                  {% endfor %}
+                </table>
+
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:0 0 14px;">
+                  <tr>
+                    <td style="font-size:14px;color:#4b5563;padding:4px 0;">Shipping method</td>
+                    <td align="right" style="font-size:14px;color:#111827;padding:4px 0;">{{ order.shipping_label|default:"N/A" }}</td>
+                  </tr>
+                  <tr>
+                    <td style="font-size:14px;color:#4b5563;padding:4px 0;">Shipping cost</td>
+                    <td align="right" style="font-size:14px;color:#111827;padding:4px 0;">${{ order.shipping_price|floatformat:2 }}</td>
+                  </tr>
+                  <tr>
+                    <td style="font-size:16px;padding:6px 0;"><strong>Total</strong></td>
+                    <td align="right" style="font-size:16px;padding:6px 0;"><strong>${{ order.total|floatformat:2 }}</strong></td>
+                  </tr>
+                </table>
+
+                {% if order.note %}
+                <p style="margin:0;font-size:14px;line-height:1.6;color:#374151;"><strong>Customer note:</strong> {{ order.note }}</p>
+                {% endif %}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/users/modules/ordermanager.py
+++ b/users/modules/ordermanager.py
@@ -128,25 +128,47 @@ def create_new_address(request, form):
 
 
 def send_order_confirmation_email_to_user_and_admin(order):
-    # send email to user with order details
-    if not order.email:
+    # Compatibility fix:
+    # checkout currently calls this function with order.serialize() (a dict),
+    # while this function needs full model relations (user/address/items) for email rendering.
+    if isinstance(order, dict):
+        order_id = order.get("orderid") or order.get("id")
+        if not order_id:
+            return
+        order = Orders.objects.select_related("user", "address").prefetch_related("items").filter(id=order_id).first()
+        if not order:
+            return
+
+    customer_email = order.user.email
+    if not customer_email:
         return
+
+    customer_name = order.user.first_name or (order.address.name if order.address else "Customer")
+    items = [
+        {
+            "product_name": item.product_name,
+            "quantity": item.quantity,
+            "price": item.price,
+            "subtotal": item.price * item.quantity,
+        }
+        for item in order.items.all()
+    ]
+
+    # send email to user with order details
     subject = f"Order Confirmation - Order #{order.id}"
     from_email = "Doobara <info@doobara.com>"
-    to = [order.email]
-    text_content = f"Thank you for your order #{order.id}, {order.user.first_name}!\n\n"
-    html_content = render_to_string("doobarashop/order_confirmation_email.html", {'user': order.user, 'order': order})
-    msg = EmailMultiAlternatives(subject, text_content, from_email, to) 
+    to = [customer_email]
+    text_content = f"Thank you for your order #{order.id}, {customer_name}!"
+    html_content = render_to_string("doobarashop/order_confirmation_email.html", {'user': order.user, 'order': order, 'items': items})
+    msg = EmailMultiAlternatives(subject, text_content, from_email, to)
     msg.attach_alternative(html_content, "text/html")
     msg.send()
 
     # send email to admin with order details
     subject = f"New Order Received - Order #{order.id}"
-    from_email = "Doobara <info@doobara.com>"
     to = ["info@doobara.com"]  # Replace with actual admin email
-    text_content = f"A new order has been received: Order #{order.id}, {order.user.first_name}, {order.address}\n\n"
-    html_content = render_to_string("doobarashop/order_notification_admin.html", {'user': order.user, 'order': order})
+    text_content = f"A new order has been received: Order #{order.id}, {customer_name}"
+    html_content = render_to_string("doobarashop/order_notification_admin.html", {'user': order.user, 'order': order, 'items': items})
     msg = EmailMultiAlternatives(subject, text_content, from_email, to)
     msg.attach_alternative(html_content, "text/html")
     msg.send()
-


### PR DESCRIPTION
### Motivation
- Add minimal, email-safe HTML templates for customer order confirmations and admin notifications to provide clear order communications. 
- Ensure the existing checkout flow that calls `send_order_confirmation_email_to_user_and_admin(order[1].serialize())` continues to work without changing call sites.

### Description
- Added `templates/doobarashop/order_confirmation_email.html` as a responsive, inline-styled customer email with itemized lines, shipping, totals, delivery address, and optional order note. 
- Added `templates/doobarashop/order_notification_admin.html` as a matching admin-facing email with customer details, delivery address, itemized lines, shipping info, totals, and optional note. 
- Updated `users/modules/ordermanager.py` so `send_order_confirmation_email_to_user_and_admin` accepts the serialized dict case by detecting `dict`, resolving the real `Orders` instance by `orderid`/`id`, and returning early if not found. 
- Built an `items` list with `product_name`, `quantity`, `price`, and precomputed `subtotal` and passed it into templates, and normalized use of the customer email/name for safe rendering.

### Testing
- Ran `python -m py_compile users/modules/ordermanager.py` which succeeded. 
- Ran `python manage.py check` which reported no system issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3f3873408324872175f087dec619)