### PR TITLE
Add GA4 base tag and optional Google site verification in global layout

### DIFF
--- a/doobara/context_processors.py
+++ b/doobara/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def analytics_context(request):
+    return {
+        "GOOGLE_ANALYTICS_ID": settings.GOOGLE_ANALYTICS_ID,
+        "GOOGLE_SITE_VERIFICATION": settings.GOOGLE_SITE_VERIFICATION,
+    }

--- a/doobara/settings.py
+++ b/doobara/settings.py
@@ -52,6 +52,8 @@ DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 
 
 ALLOWED_HOSTS = [host.strip() for host in os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")]
+GOOGLE_ANALYTICS_ID = os.getenv("GOOGLE_ANALYTICS_ID", "")
+GOOGLE_SITE_VERIFICATION = os.getenv("GOOGLE_SITE_VERIFICATION", "")
 
 
 # Application definition
@@ -101,6 +103,7 @@ template_context_processors = [
     'django.contrib.auth.context_processors.auth',
     'django.contrib.messages.context_processors.messages',
     'cart.views.cartcontext',
+    'doobara.context_processors.analytics_context',
 ]
 
 if DEBUG:

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -5,6 +5,18 @@
     <meta charset="UTF-8" />
     <title>Doobra, Smarter Living, Modern Design</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {% if GOOGLE_SITE_VERIFICATION %}
+    <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">
+    {% endif %}
+    {% if GOOGLE_ANALYTICS_ID %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
+    </script>
+    {% endif %}
       <!-- CSS and JS -->
       <link href="{% static 'doobarashop/style.css' %}" rel="stylesheet">
       <script type="module" src="{% static 'doobarashop/js/bootstrap.js' %}"></script>


### PR DESCRIPTION
### Motivation
- Add Google Analytics 4 (GA4) base snippet and optional Google Search Console verification to the global layout so analytics and verification can be enabled via environment configuration without third-party packages.
- Keep the implementation minimal, production-safe, and avoid changes to unrelated layout, styling, or business logic.

### Description
- Add two environment-driven settings in `doobara/settings.py`: `GOOGLE_ANALYTICS_ID = os.getenv("GOOGLE_ANALYTICS_ID", "")` and `GOOGLE_SITE_VERIFICATION = os.getenv("GOOGLE_SITE_VERIFICATION", "")`.
- Add `doobara/context_processors.py` with `analytics_context` that exposes `GOOGLE_ANALYTICS_ID` and `GOOGLE_SITE_VERIFICATION` to templates.
- Register the new context processor in the global template context processors in `doobara/settings.py` so values are available to every template.
- Insert the GA4 gtag snippet and the optional Search Console meta tag into the global layout `templates/doobarashop/layout.html` inside the `<head>`, each wrapped in `{% if ... %}` so the code only renders when the corresponding environment variable is set.

### Testing
- Ran Django system checks with dummy environment variables using `SECRET_KEY=dummy DEBUG=True DB_NAME=dummy DB_USER=dummy DB_PASSWORD=dummy DB_HOST=localhost DB_PORT=5432 python manage.py check` and the check completed successfully with no issues.
- No other automated tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea6eddd748324ac14e8657307184c)