### PR TITLE
Add GA4 ecommerce events and currency metadata; fire add_to_cart only after successful API adds

### DIFF
--- a/cart/models.py
+++ b/cart/models.py
@@ -57,6 +57,7 @@ class Cart_Item (models.Model):
     def serialize(self):
         target_name = self.variant.title if self.variant else self.product.name
         target_price = self.variant.sale_price if self.variant and self.variant.sale_price else (self.variant.price if self.variant else self.product.price)
+        target_currency = self.variant.currency if self.variant else self.product.currency
         if self.variant:
             image = self.variant.images.filter(thumbnail=True).first() or self.variant.images.first()
             cart_key = f"v-{self.variant.id}"
@@ -68,6 +69,7 @@ class Cart_Item (models.Model):
             "productid" : self.product.id,
             "productname" : target_name,
             "productunitprice" : target_price,
+            "productcurrency": target_currency,
             "productquantity": self.quantity,
             "productimage": image,
             "cartkey": cart_key,

--- a/cart/modules/snippethelper.py
+++ b/cart/modules/snippethelper.py
@@ -82,6 +82,7 @@ def scart_data_setup(cart, lst=None):
             if not variant:
                 continue
             price = variant.sale_price if variant.sale_price else variant.price
+            currency = variant.currency
             image = variant.images.filter(thumbnail=True).first() or variant.images.first()
             name = variant.title
             product_id = variant.product.id
@@ -90,6 +91,7 @@ def scart_data_setup(cart, lst=None):
             if not product:
                 continue
             price = product.price
+            currency = product.currency
             # PERF: one query path instead of .exists()+.first() double query.
             image = product.images.filter(thumbnail=True).first() or product.images.first()
             name = product.name
@@ -99,6 +101,7 @@ def scart_data_setup(cart, lst=None):
             "productname": name,
             "productid": product_id,
             "productunitprice": price,
+            "productcurrency": currency,
             "productquantity": quantity,
             "productimage": image,
             "cartkey": key,

--- a/cart/templates/cart/checkout.html
+++ b/cart/templates/cart/checkout.html
@@ -204,4 +204,24 @@ My Cart
         </div>
     </div>
 </section>
+
+<script>
+  // GA4 analytics: checkout-start event.
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'begin_checkout', {
+      currency: '{% if cart and cart.0.0.productcurrency %}{{ cart.0.0.productcurrency|escapejs }}{% else %}USD{% endif %}',
+      value: Number('{{ grand_total|floatformat:2 }}'),
+      items: [
+        {% for item in cart %}
+        {
+          item_id: '{{ item.0.productid }}',
+          item_name: '{{ item.0.productname|escapejs }}',
+          price: Number('{{ item.0.productunitprice|floatformat:2 }}'),
+          quantity: {{ item.0.productquantity }}
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+      ]
+    });
+  }
+</script>
 {% endblock %}

--- a/shop/modeling/serialize_helper.py
+++ b/shop/modeling/serialize_helper.py
@@ -81,6 +81,7 @@ def product_serialize(object, tag):
             "pid": object.id,
             "pname": object.name,
             "pprice": object.price,
+            "currency": object.currency,
             "pshortdescription": short_description_lines,
             "plongdescription": long_description,
             "pvideo": object.video,
@@ -93,4 +94,3 @@ def product_serialize(object, tag):
             "dimensions": object.dimensions,
             "weight": object.weight,
         }
-

--- a/shop/templates/shop/shop.html
+++ b/shop/templates/shop/shop.html
@@ -71,7 +71,14 @@ SHOP
                         </div>
                     </a>
 
-                    <button class="shop-card__btn shop-add-to-cart" value="{{row.pid}}">
+                    {# GA4 analytics metadata for add_to_cart from shop listing cards. #}
+                    <button class="shop-card__btn shop-add-to-cart"
+                            value="{{row.pid}}"
+                            data-ga-item-id="{{ row.pid }}"
+                            data-ga-item-name="{{ row.pname|escapejs }}"
+                            data-ga-price="{{ row.pprice|floatformat:2 }}"
+                            data-ga-currency="{{ row.currency|default:'USD' }}"
+                            data-ga-item-category="{% if row.pcategory.0 %}{{ row.pcategory.0.name|escapejs }}{% endif %}">
                         Add to Cart
                     </button>
                 </article>

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -49,10 +49,16 @@
                     </div>
 
                     <div class="single-product-purchase">
+                        {# GA4 analytics metadata for add_to_cart (system variant path). #}
                         <button
                             id="spatc"
                             class="single-product-addtocart shop-add-to-cart"
-                            data-variant-id="{{ default_variant.id }}">
+                            data-variant-id="{{ default_variant.id }}"
+                            data-ga-item-id="{{ default_variant.id }}"
+                            data-ga-item-name="{{ default_variant.title|escapejs }}"
+                            data-ga-price="{% if default_variant.sale_price %}{{ default_variant.sale_price|floatformat:2 }}{% else %}{{ default_variant.price|floatformat:2 }}{% endif %}"
+                            data-ga-currency="{{ product.currency|default:'USD' }}"
+                            data-ga-item-category="{% if product.pcategory.0 %}{{ product.pcategory.0.name|escapejs }}{% endif %}">
                             Add to Cart
                         </button>
                     </div>
@@ -123,10 +129,15 @@
                             <label for="spq">Quantity</label>
                             <input id="spq" class="single-product-quantity" type="number" value="1" min="1">
                         </div>
-
+                        {# GA4 analytics metadata for add_to_cart (standard product path). #}
                         <button id="spatc"
                                 class="single-product-addtocart shop-add-to-cart"
-                                value="{{ product.pid }}">
+                                value="{{ product.pid }}"
+                                data-ga-item-id="{{ product.pid }}"
+                                data-ga-item-name="{{ product.pname|escapejs }}"
+                                data-ga-price="{{ product.pprice|floatformat:2 }}"
+                                data-ga-currency="{{ product.currency|default:'USD' }}"
+                                data-ga-item-category="{% if product.pcategory.0 %}{{ product.pcategory.0.name|escapejs }}{% endif %}">
                             Add to Cart
                         </button>
                     </div>
@@ -207,5 +218,22 @@
 
     </div>
 </section>
+
+<script>
+  // GA4 analytics: product detail view event.
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'view_item', {
+      currency: '{{ product.currency|default:"USD"|escapejs }}',
+      value: Number('{% if product.system and default_variant %}{% if default_variant.sale_price %}{{ default_variant.sale_price|floatformat:2 }}{% else %}{{ default_variant.price|floatformat:2 }}{% endif %}{% else %}{{ product.pprice|floatformat:2 }}{% endif %}'),
+      items: [{
+        item_id: '{% if product.system and default_variant %}{{ default_variant.id }}{% else %}{{ product.pid }}{% endif %}',
+        item_name: '{% if product.system and default_variant %}{{ default_variant.title|escapejs }}{% else %}{{ product.pname|escapejs }}{% endif %}',
+        price: Number('{% if product.system and default_variant %}{% if default_variant.sale_price %}{{ default_variant.sale_price|floatformat:2 }}{% else %}{{ default_variant.price|floatformat:2 }}{% endif %}{% else %}{{ product.pprice|floatformat:2 }}{% endif %}'),
+        quantity: 1,
+        item_category: '{% if product.pcategory.0 %}{{ product.pcategory.0.name|escapejs }}{% endif %}'
+      }]
+    });
+  }
+</script>
 
 {% endblock %}

--- a/shop/views.py
+++ b/shop/views.py
@@ -104,6 +104,7 @@ def single_product(request, locat):
             "description": variant.description,
             "price": float(variant.price),
             "sale_price": float(variant.sale_price) if variant.sale_price else None,
+            "currency": variant.currency,
             "thumbnail": thumb.image.url if thumb else None,
             "images": images,
             "package_items": package_items,

--- a/static/doobarashop/js/features/cartActions.js
+++ b/static/doobarashop/js/features/cartActions.js
@@ -1,5 +1,31 @@
 import { sendJson } from '../core/http.js';
 
+// GA4 analytics: emit add_to_cart only after a successful backend add.
+function trackAddToCart(button, quantity) {
+  if (typeof window.gtag !== 'function') {
+    return;
+  }
+
+  const itemPrice = Number.parseFloat(button.dataset.gaPrice || '0');
+  const itemQuantity = Number.parseInt(quantity, 10) || 1;
+  const item = {
+    item_id: button.dataset.gaItemId || button.value,
+    item_name: button.dataset.gaItemName || '',
+    price: itemPrice,
+    quantity: itemQuantity,
+  };
+
+  if (button.dataset.gaItemCategory) {
+    item.item_category = button.dataset.gaItemCategory;
+  }
+
+  window.gtag('event', 'add_to_cart', {
+    currency: button.dataset.gaCurrency || 'USD',
+    value: Number((itemPrice * itemQuantity).toFixed(2)),
+    items: [item],
+  });
+}
+
 function updateCartSummary(cart) {
   const cartItemsElement = document.getElementById('cartitemsqtt');
   const footerItemsElement = document.getElementById('footeritemqtt');
@@ -46,8 +72,10 @@ function bindAddToCartButtons() {
 
       const result = await response.json();
 
-      if (result.result !== 'login') {
+      // GA4 analytics: fire add_to_cart only when API confirms success.
+      if (result.result === 'done') {
         updateCartSummary(result.cart);
+        trackAddToCart(button, quantity);
       }
     });
   });

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -1,5 +1,30 @@
 import { sendJson } from '../core/http.js';
 
+// GA4 analytics: emit add_to_cart for system variants only after successful add.
+function trackAddToCart(button) {
+  if (typeof window.gtag !== 'function') {
+    return;
+  }
+
+  const itemPrice = Number.parseFloat(button.dataset.gaPrice || '0');
+  const item = {
+    item_id: button.dataset.gaItemId || button.dataset.variantId || '',
+    item_name: button.dataset.gaItemName || '',
+    price: itemPrice,
+    quantity: 1,
+  };
+
+  if (button.dataset.gaItemCategory) {
+    item.item_category = button.dataset.gaItemCategory;
+  }
+
+  window.gtag('event', 'add_to_cart', {
+    currency: button.dataset.gaCurrency || 'USD',
+    value: Number(itemPrice.toFixed(2)),
+    items: [item],
+  });
+}
+
 function updateCartSummary(cart) {
   const cartItemsElement = document.getElementById('cartitemsqtt');
   const footerItemsElement = document.getElementById('footeritemqtt');
@@ -42,6 +67,10 @@ function renderVariant(variant) {
 
   if (addToCartButton) {
     addToCartButton.dataset.variantId = String(variant.id);
+    addToCartButton.dataset.gaItemId = String(variant.id);
+    addToCartButton.dataset.gaItemName = variant.title || '';
+    addToCartButton.dataset.gaPrice = String(variant.sale_price ?? variant.price ?? 0);
+    addToCartButton.dataset.gaCurrency = variant.currency || addToCartButton.dataset.gaCurrency || 'USD';
   }
 
   if (gallery) {
@@ -154,8 +183,10 @@ export function initSystemVariants() {
     });
 
     const result = await response.json();
-    if (result.result !== 'login') {
+    // GA4 analytics: fire add_to_cart only when API confirms success.
+    if (result.result === 'done') {
       updateCartSummary(result.cart);
+      trackAddToCart(addToCartButton);
     }
   });
 }

--- a/users/models.py
+++ b/users/models.py
@@ -99,6 +99,7 @@ class Orders (models.Model):
             "orderid": self.id,
             "status": self.status,
             "total": self.total,
+            "currency": self.currency,
             "shipping_method": self.shipping_label,
             "shipping_price": self.shipping_price,
             "note": self.note,

--- a/users/templates/users/orderplace.html
+++ b/users/templates/users/orderplace.html
@@ -76,4 +76,25 @@ Order Placed
 
     </div>
 </section>
+<script>
+  // GA4 analytics: purchase event on successful order confirmation page.
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'purchase', {
+      transaction_id: '{{ order.orderid }}',
+      value: Number('{{ order.total|floatformat:2 }}'),
+      currency: '{{ order.currency|default:"USD"|escapejs }}',
+      items: [
+        {% for item in order_items %}
+        {
+          item_id: '{{ item.item_id }}',
+          item_name: '{{ item.item_name|escapejs }}',
+          price: Number('{{ item.price|floatformat:2 }}'),
+          quantity: {{ item.quantity }},
+          item_category: '{{ item.item_category|escapejs }}'
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+      ]
+    });
+  }
+</script>
 {% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -51,8 +51,33 @@ def placeorder(request):
             # text to be shown on html page
             success = "Thank you for Your order"
             send_order_confirmation_email_to_user_and_admin(order[1].serialize())
+            order_items = order[1].items.select_related("product").all()
+            # GA4 analytics payload source for purchase event on thank-you page.
+            analytics_items = []
+            for item in order_items:
+                category = ""
+                if item.product:
+                    first_category = item.product.category.first()
+                    category = first_category.name if first_category else ""
+                analytics_items.append(
+                    {
+                        "item_id": item.product.id if item.product else "",
+                        "item_name": item.product_name,
+                        "price": item.price,
+                        "quantity": item.quantity,
+                        "item_category": category,
+                    }
+                )
 
-            return render(request, "users/orderplace.html", {'ordermessage':success, "order": order[1].serialize()})
+            return render(
+                request,
+                "users/orderplace.html",
+                {
+                    'ordermessage': success,
+                    "order": order[1].serialize(),
+                    "order_items": analytics_items,
+                },
+            )
         # If new form have invalid data return same form and chekout page to retry
         else:
             pricing = cart_pricing_breakdown(request)


### PR DESCRIPTION
### Motivation
- Surface product and order currency in serialized payloads so analytics events include correct currency values.
- Instrument key user flows with GA4 ecommerce events (`view_item`, `begin_checkout`, `add_to_cart`, `purchase`).
- Ensure `add_to_cart` analytics are emitted only after the backend confirms a successful cart update.

### Description
- Include currency on cart/variant/product serialization by adding `productcurrency` in `Cart_Item.serialize`, `productcurrency` in `scart_data_setup`, and `currency` in `shop/modeling/serialize_helper.py` and `shop/views.single_product` variant payloads.
- Expose order `currency` in `Orders.serialize` and build an `order_items` analytics payload in `users.views.placeorder` that is passed to the `orderplace.html` template.
- Augment templates to include GA4 metadata and inline `gtag` calls: add `data-ga-*` attributes on add-to-cart buttons in `shop.html` and `single_product.html`, add `view_item` in `single_product.html`, `begin_checkout` in `checkout.html`, and `purchase` in `orderplace.html`.
- Update frontend JS (`cartActions.js` and `systemVariants.js`) to attach analytics metadata to buttons and to call `gtag('event', 'add_to_cart', ...)` only after the add-to-cart API returns success, via new `trackAddToCart` helper functions.

### Testing
- Ran the Django test suite with `./manage.py test`, and the tests completed successfully.
- Ran frontend checks including `npm run lint` and a local build/smoke check of the modified pages, and no issues were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beac266c3c8324a807158c263bc170)