### PR TITLE
Add built-in Django sitemap.xml for public indexable pages

### DIFF
--- a/doobara/settings.py
+++ b/doobara/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sitemaps',
     # new allauth
     'django.contrib.sites',
     'allauth',

--- a/doobara/sitemaps.py
+++ b/doobara/sitemaps.py
@@ -1,0 +1,44 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from shop.models import Categorie, Product
+
+
+class StaticViewSitemap(Sitemap):
+    priority = 0.8
+    changefreq = "weekly"
+
+    def items(self):
+        return ["index", "shop", "contactus", "blog", "single_blog_post"]
+
+    def location(self, item):
+        return reverse(item)
+
+
+class CategorySitemap(Sitemap):
+    priority = 0.7
+    changefreq = "weekly"
+
+    def items(self):
+        return (
+            Categorie.objects.filter(products__active=True)
+            .distinct()
+            .order_by("name")
+        )
+
+    def location(self, item):
+        return reverse("filtering", kwargs={"locat": item.name})
+
+
+class ProductSitemap(Sitemap):
+    priority = 0.9
+    changefreq = "weekly"
+
+    def items(self):
+        return Product.objects.filter(active=True).order_by("name")
+
+    def location(self, item):
+        return reverse("single_product", kwargs={"locat": item.name})
+
+    def lastmod(self, item):
+        return item.updated_time

--- a/doobara/urls.py
+++ b/doobara/urls.py
@@ -14,10 +14,19 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
+
+from .sitemaps import CategorySitemap, ProductSitemap, StaticViewSitemap
 
 def trigger_error(request):
     division_by_zero = 1 / 0
+
+sitemaps = {
+    "static": StaticViewSitemap,
+    "categories": CategorySitemap,
+    "products": ProductSitemap,
+}
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -25,5 +34,6 @@ urlpatterns = [
     path("", include("cart.urls")),
     path("", include("users.urls")),
     path("", include("blog.urls")),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
     path('sentry-debug/', trigger_error)
 ]


### PR DESCRIPTION
### Motivation
- Provide a simple, explicit XML sitemap for public indexable pages using Django’s built-in sitemap framework and avoid third‑party packages. 
- Ensure only canonical, indexable marketing/shop/blog/category/product pages are exposed and sensitive/utility routes (cart, checkout, account, admin, search, etc.) are excluded.

### Description
- Added `doobara/sitemaps.py` with three Sitemap classes: `StaticViewSitemap` (home/shop/contact/blog/static pages), `CategorySitemap` (only categories that have active products), and `ProductSitemap` (only active products) with `lastmod` sourced from `Product.updated_time`.
- Mounted the sitemaps in `doobara/urls.py` at `/sitemap.xml` using `django.contrib.sitemaps.views.sitemap` and a `sitemaps` dict mapping the three classes.
- Enabled the sitemap framework by adding `'django.contrib.sitemaps'` to `INSTALLED_APPS` in `doobara/settings.py`.
- Implementation keeps canonical URL names from existing views (`index`, `shop`, `contactus`, `blog`, `single_blog_post`, `filtering`, `single_product`) and intentionally omits cart/checkout/account/admin/search/filter endpoints.

### Testing
- Ran `SECRET_KEY=test DEBUG=true DB_ENGINE=django.db.backends.sqlite3 DB_NAME=/tmp/doobara.sqlite3 python manage.py check` and it completed with no issues.
- Ran `SECRET_KEY=test DEBUG=true DB_ENGINE=django.db.backends.sqlite3 DB_NAME=/tmp/doobara.sqlite3 python manage.py shell -c "from django.urls import reverse; print(reverse('sitemap'))"` and it returned `/sitemap.xml` indicating the route is registered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec66d58488324b4cc117cfc6dd462)