### PR TITLE
Add Meta Pixel tracking and integrate with existing GA4 events

### DIFF
--- a/cart/templates/cart/checkout.html
+++ b/cart/templates/cart/checkout.html
@@ -206,6 +206,17 @@ My Cart
 </section>
 
 <script>
+  // Meta Pixel: checkout start event.
+  if (typeof window.fbq === 'function') {
+    window.fbq('track', 'InitiateCheckout', {
+      content_ids: [{% for item in cart %}'{{ item.0.productid }}'{% if not forloop.last %}, {% endif %}{% endfor %}],
+      content_type: 'product',
+      num_items: {{ cart|length }},
+      value: Number('{{ grand_total|floatformat:2 }}'),
+      currency: '{% if cart and cart.0.0.productcurrency %}{{ cart.0.0.productcurrency|escapejs }}{% else %}USD{% endif %}'
+    });
+  }
+
   // GA4 analytics: checkout-start event.
   if (typeof window.gtag === 'function') {
     window.gtag('event', 'begin_checkout', {

--- a/doobara/context_processors.py
+++ b/doobara/context_processors.py
@@ -5,4 +5,6 @@ def analytics_context(request):
     return {
         "GOOGLE_ANALYTICS_ID": settings.GOOGLE_ANALYTICS_ID,
         "GOOGLE_SITE_VERIFICATION": settings.GOOGLE_SITE_VERIFICATION,
+        # Meta Pixel id for template usage.
+        "META_PIXEL_ID": settings.META_PIXEL_ID,
     }

--- a/doobara/settings.py
+++ b/doobara/settings.py
@@ -54,6 +54,8 @@ DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 ALLOWED_HOSTS = [host.strip() for host in os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")]
 GOOGLE_ANALYTICS_ID = os.getenv("GOOGLE_ANALYTICS_ID", "")
 GOOGLE_SITE_VERIFICATION = os.getenv("GOOGLE_SITE_VERIFICATION", "")
+# Meta Pixel configuration.
+META_PIXEL_ID = os.getenv("META_PIXEL_ID", "")
 
 
 # Application definition

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -220,6 +220,17 @@
 </section>
 
 <script>
+  // Meta Pixel: product detail view event.
+  if (typeof window.fbq === 'function') {
+    window.fbq('track', 'ViewContent', {
+      content_ids: ['{% if product.system and default_variant %}{{ default_variant.id }}{% else %}{{ product.pid }}{% endif %}'],
+      content_name: '{% if product.system and default_variant %}{{ default_variant.title|escapejs }}{% else %}{{ product.pname|escapejs }}{% endif %}',
+      content_type: 'product',
+      value: Number('{% if product.system and default_variant %}{% if default_variant.sale_price %}{{ default_variant.sale_price|floatformat:2 }}{% else %}{{ default_variant.price|floatformat:2 }}{% endif %}{% else %}{{ product.pprice|floatformat:2 }}{% endif %}'),
+      currency: '{{ product.currency|default:"USD"|escapejs }}'
+    });
+  }
+
   // GA4 analytics: product detail view event.
   if (typeof window.gtag === 'function') {
     window.gtag('event', 'view_item', {

--- a/static/doobarashop/js/features/cartActions.js
+++ b/static/doobarashop/js/features/cartActions.js
@@ -1,16 +1,20 @@
 import { sendJson } from '../core/http.js';
 
-// GA4 analytics: emit add_to_cart only after a successful backend add.
+// GA4 + Meta Pixel analytics: emit add_to_cart/AddToCart only after a successful backend add.
 function trackAddToCart(button, quantity) {
+  const itemId = button.dataset.gaItemId || button.value;
+  const itemName = button.dataset.gaItemName || '';
   if (typeof window.gtag !== 'function') {
-    return;
+    if (typeof window.fbq !== 'function') {
+      return;
+    }
   }
 
   const itemPrice = Number.parseFloat(button.dataset.gaPrice || '0');
   const itemQuantity = Number.parseInt(quantity, 10) || 1;
   const item = {
-    item_id: button.dataset.gaItemId || button.value,
-    item_name: button.dataset.gaItemName || '',
+    item_id: itemId,
+    item_name: itemName,
     price: itemPrice,
     quantity: itemQuantity,
   };
@@ -19,11 +23,28 @@ function trackAddToCart(button, quantity) {
     item.item_category = button.dataset.gaItemCategory;
   }
 
-  window.gtag('event', 'add_to_cart', {
-    currency: button.dataset.gaCurrency || 'USD',
-    value: Number((itemPrice * itemQuantity).toFixed(2)),
-    items: [item],
-  });
+  const currency = button.dataset.gaCurrency || 'USD';
+  const value = Number((itemPrice * itemQuantity).toFixed(2));
+
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'add_to_cart', {
+      currency,
+      value,
+      items: [item],
+    });
+  }
+
+  if (typeof window.fbq === 'function') {
+    // Meta Pixel: AddToCart standard event.
+    window.fbq('track', 'AddToCart', {
+      content_ids: [itemId],
+      content_name: itemName,
+      content_type: 'product',
+      value,
+      currency,
+      num_items: itemQuantity,
+    });
+  }
 }
 
 function updateCartSummary(cart) {

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -1,15 +1,19 @@
 import { sendJson } from '../core/http.js';
 
-// GA4 analytics: emit add_to_cart for system variants only after successful add.
+// GA4 + Meta Pixel analytics: emit add_to_cart/AddToCart for system variants only after successful add.
 function trackAddToCart(button) {
+  const itemId = button.dataset.gaItemId || button.dataset.variantId || '';
+  const itemName = button.dataset.gaItemName || '';
   if (typeof window.gtag !== 'function') {
-    return;
+    if (typeof window.fbq !== 'function') {
+      return;
+    }
   }
 
   const itemPrice = Number.parseFloat(button.dataset.gaPrice || '0');
   const item = {
-    item_id: button.dataset.gaItemId || button.dataset.variantId || '',
-    item_name: button.dataset.gaItemName || '',
+    item_id: itemId,
+    item_name: itemName,
     price: itemPrice,
     quantity: 1,
   };
@@ -18,11 +22,28 @@ function trackAddToCart(button) {
     item.item_category = button.dataset.gaItemCategory;
   }
 
-  window.gtag('event', 'add_to_cart', {
-    currency: button.dataset.gaCurrency || 'USD',
-    value: Number(itemPrice.toFixed(2)),
-    items: [item],
-  });
+  const currency = button.dataset.gaCurrency || 'USD';
+  const value = Number(itemPrice.toFixed(2));
+
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'add_to_cart', {
+      currency,
+      value,
+      items: [item],
+    });
+  }
+
+  if (typeof window.fbq === 'function') {
+    // Meta Pixel: AddToCart standard event.
+    window.fbq('track', 'AddToCart', {
+      content_ids: [itemId],
+      content_name: itemName,
+      content_type: 'product',
+      value,
+      currency,
+      num_items: 1,
+    });
+  }
 }
 
 function updateCartSummary(cart) {

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -17,6 +17,21 @@
       gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
     </script>
     {% endif %}
+    {% if META_PIXEL_ID %}
+    {# Meta Pixel: base code + PageView (global) #}
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '{{ META_PIXEL_ID|escapejs }}');
+      fbq('track', 'PageView');
+    </script>
+    {% endif %}
       <!-- CSS and JS -->
       <link href="{% static 'doobarashop/style.css' %}" rel="stylesheet">
       <script type="module" src="{% static 'doobarashop/js/bootstrap.js' %}"></script>
@@ -31,6 +46,13 @@
   </head>
 
   <body>
+    {% if META_PIXEL_ID %}
+    {# Meta Pixel: noscript fallback #}
+    <noscript>
+      <img height="1" width="1" style="display:none"
+           src="https://www.facebook.com/tr?id={{ META_PIXEL_ID|urlencode }}&ev=PageView&noscript=1" alt="">
+    </noscript>
+    {% endif %}
     <div class="page">
       <!-- Header / Navigation -->
       <header>

--- a/users/templates/users/orderplace.html
+++ b/users/templates/users/orderplace.html
@@ -77,6 +77,17 @@ Order Placed
     </div>
 </section>
 <script>
+  // Meta Pixel: purchase event on successful order confirmation page.
+  if (typeof window.fbq === 'function') {
+    window.fbq('track', 'Purchase', {
+      content_ids: [{% for item in order_items %}'{{ item.item_id }}'{% if not forloop.last %}, {% endif %}{% endfor %}],
+      content_type: 'product',
+      value: Number('{{ order.total|floatformat:2 }}'),
+      currency: '{{ order.currency|default:"USD"|escapejs }}',
+      num_items: {{ order_items|length }}
+    });
+  }
+
   // GA4 analytics: purchase event on successful order confirmation page.
   if (typeof window.gtag === 'function') {
     window.gtag('event', 'purchase', {


### PR DESCRIPTION
### Motivation
- Add Meta Pixel (Facebook) tracking across the storefront to capture PageView, ViewContent, AddToCart, InitiateCheckout and Purchase events alongside existing GA4 events.
- Expose a configuration value so templates can initialize the Meta Pixel when `META_PIXEL_ID` is provided.

### Description
- Introduce `META_PIXEL_ID` in `doobara/settings.py` and expose it via `analytics_context` in `doobara/context_processors.py` so templates can access the ID.
- Inject Meta Pixel base code and a `noscript` fallback into `templates/doobarashop/layout.html` when `META_PIXEL_ID` is set to enable global `fbq` usage and `PageView` tracking.
- Emit Meta Pixel events in relevant templates: add `ViewContent` in `shop/templates/shop/single_product.html`, `InitiateCheckout` in `cart/templates/cart/checkout.html`, and `Purchase` in `users/templates/users/orderplace.html` using the same product/order data already rendered for GA4.
- Update frontend tracking in `static/doobarashop/js/features/cartActions.js` and `static/doobarashop/js/features/systemVariants.js` to emit `AddToCart` via `fbq('track', 'AddToCart', ...)` following successful backend adds, to compute `value`/`currency`, and to gracefully handle the presence or absence of `gtag` and `fbq` by checking `typeof window.gtag` and `typeof window.fbq`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed69f17048324b8ad08566fd22d0e)