### PR TITLE
Add production-safe robots.txt served from site root

### DIFF
--- a/doobara/urls.py
+++ b/doobara/urls.py
@@ -11,11 +11,13 @@ Class-based views
     2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.urls import include, path
+from django.views.generic import TemplateView
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 from .sitemaps import CategorySitemap, ProductSitemap, StaticViewSitemap
 
@@ -29,6 +31,11 @@ sitemaps = {
 }
 
 urlpatterns = [
+    path(
+        'robots.txt',
+        TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
+        name='robots_txt',
+    ),
     path('admin/', admin.site.urls),
     path("", include("shop.urls")),
     path("", include("cart.urls")),

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+Disallow: /admin/
+Disallow: /checkout
+Disallow: /cart
+Disallow: /accounts/
+Disallow: /myaccount
+Disallow: /logout
+Disallow: /placeorder
+Disallow: /order_log
+Disallow: /address_list
+Disallow: /new_edit_address
+Disallow: /update_address
+Disallow: /shopaddtocart
+Disallow: /updatecart
+
+Sitemap: https://doobara.com/sitemap.xml


### PR DESCRIPTION
### Motivation
- Serve a simple, production-safe `robots.txt` at the site root to support SEO while preventing indexing of obvious utility pages (admin, cart/checkout, account/order actions) without changing other routes or templates.

### Description
- Added a root route that serves a plain-text `robots.txt` via `TemplateView` in `doobara/urls.py` and added `templates/robots.txt` containing `User-agent: *` plus Disallow rules for admin/cart/checkout/accounts and related utility endpoints and a `Sitemap: https://doobara.com/sitemap.xml` directive.

### Testing
- Ran `python manage.py check`, which failed in this environment due to a missing dependency (`sentry_sdk`) and not due to the `robots.txt` changes, and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c013847cfc83249771ac90a19db2f9)