### PR TITLE
Add canonical link support for public pages and enforce slug canonical for products

### DIFF
--- a/doobara/context_processors.py
+++ b/doobara/context_processors.py
@@ -1,4 +1,52 @@
 from django.conf import settings
+from django.urls import NoReverseMatch, reverse
+
+
+# Routes that should emit <link rel="canonical"> because they are public/indexable.
+# Keeping this list explicit avoids adding canonicals to utility/account/cart flows.
+CANONICAL_ROUTE_NAMES = {
+    "index",
+    "shop",
+    "filtering",
+    "contactus",
+    "blog",
+    "video",
+    "single_blog_post",
+    "single_product_by_slug",
+    "single_product",
+}
+
+
+def _get_canonical_url(request):
+    """
+    Build the preferred absolute canonical URL for known indexable routes.
+
+    Purpose:
+    - Centralize canonical URL generation in one predictable place.
+    - Limit canonical tags to explicitly approved public pages only.
+    - Always return an absolute URL when a canonical should be emitted.
+    """
+    resolver_match = getattr(request, "resolver_match", None)
+    if not resolver_match or resolver_match.url_name not in CANONICAL_ROUTE_NAMES:
+        return None
+
+    url_name = resolver_match.url_name
+
+    # Product pages should always canonicalize to the slug route,
+    # even when a legacy name-based URL is used.
+    if url_name in {"single_product", "single_product_by_slug"}:
+        slug = resolver_match.kwargs.get("slug")
+        if slug:
+            path = reverse("single_product_by_slug", kwargs={"slug": slug})
+            return request.build_absolute_uri(path)
+        return None
+
+    try:
+        path = reverse(url_name, kwargs=resolver_match.kwargs)
+    except NoReverseMatch:
+        return None
+
+    return request.build_absolute_uri(path)
 
 
 def analytics_context(request):
@@ -7,4 +55,5 @@ def analytics_context(request):
         "GOOGLE_SITE_VERIFICATION": settings.GOOGLE_SITE_VERIFICATION,
         # Meta Pixel id for template usage.
         "META_PIXEL_ID": settings.META_PIXEL_ID,
+        "canonical_url": _get_canonical_url(request),
     }

--- a/shop/views.py
+++ b/shop/views.py
@@ -238,6 +238,8 @@ def single_product(request, locat=None, slug=None):
             "product": product,
             "variants": variants,
             "default_variant": default_variant,
+            # Always canonicalize product detail pages to the slug-based product URL.
+            "canonical_url": request.build_absolute_uri(parent_product.get_absolute_url()),
             "product_json_ld": _json_for_script_tag(
                 # JSON string consumed directly by <script type="application/ld+json">.
                 _build_product_json_ld(

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -17,6 +17,9 @@
       gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
     </script>
     {% endif %}
+    {% if canonical_url %}
+    <link rel="canonical" href="{{ canonical_url }}">
+    {% endif %}
     {% if META_PIXEL_ID %}
     {# Meta Pixel: base code + PageView (global) #}
     <script>


### PR DESCRIPTION
### Motivation
- Emit clean `rel="canonical"` tags for indexable public pages from the global base template to improve SEO and avoid duplicate-content signals.
- Centralize canonical URL generation and keep canonicals off utility/non-indexable routes by using an explicit allowlist and reusing existing `get_absolute_url` behaviour for products.

### Description
- Added `_get_canonical_url(request)` and an explicit `CANONICAL_ROUTE_NAMES` allowlist to `doobara/context_processors.py`, documented with comments and returning absolute URLs via `request.build_absolute_uri()` when appropriate.
- Wired the canonical URL into the global template context as `canonical_url` from the existing analytics context processor so templates can emit the tag without changing view logic for most pages.
- Inserted a conditional `<link rel="canonical" href="{{ canonical_url }}">` into `templates/doobarashop/layout.html` inside the `<head>` so canonicals are only emitted when present.
- Ensured product detail pages explicitly provide a slug-based absolute canonical by adding `canonical_url: request.build_absolute_uri(parent_product.get_absolute_url())` to the `single_product` view, so legacy/name-based access canonicalizes to the slug route.

### Testing
- Ran `python manage.py check`, which could not complete in this environment because the `sentry_sdk` dependency is missing and Django settings fail to import (automated check failed for environment reasons).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01726553083249168cce5872cbabd)