### PR TITLE
Add dedicated internal product feed export for catalog readiness

### DIFF
--- a/docs/catalog-feed-readiness.md
+++ b/docs/catalog-feed-readiness.md
@@ -1,0 +1,44 @@
+# Catalog Feed Readiness (Google Merchant + Meta Commerce)
+
+This project now includes a **dedicated internal product feed export layer** that is intentionally separate from storefront serializers/templates.
+
+## Internal endpoint
+
+- `GET /internal/exports/products.json`
+
+## Export fields (v1)
+
+Each product row includes these keys:
+
+- `id`
+- `title`
+- `description`
+- `url` (canonical absolute product URL)
+- `image_url` (absolute and null-safe)
+- `price` (2-decimal string)
+- `currency`
+- `availability` (`in stock`, `out of stock`, `preorder`)
+- `brand`
+- `sku`
+- `condition` (currently `null`; documented gap)
+- `missing_fields` (explicit per-row gap visibility)
+
+## Availability normalization
+
+Availability is normalized using existing inventory rules:
+
+1. `preorder` when product inventory marks `is_preorder=True`
+2. `in stock` when normalized quantity is greater than 0
+3. `out of stock` otherwise
+
+## Readiness gaps (blocking full Merchant/Meta readiness)
+
+The feed payload exposes global readiness gaps under `readiness_gaps`.
+Current known gaps:
+
+- `condition` source field is not stored on `Product`
+- `gtin_mpn` fields are missing
+- `google_product_category` mapping is missing
+- `meta_fb_product_category` mapping is missing
+
+These should be added in later iterations before direct API submissions.

--- a/docs/catalog-feed-readiness.md
+++ b/docs/catalog-feed-readiness.md
@@ -6,7 +6,7 @@ This project now includes a **dedicated internal product feed export layer** tha
 
 - `GET /internal/exports/products.json`
 
-## Export fields (v1)
+## Export fields (v2)
 
 Each product row includes these keys:
 
@@ -20,7 +20,10 @@ Each product row includes these keys:
 - `availability` (`in stock`, `out of stock`, `preorder`)
 - `brand`
 - `sku`
-- `condition` (currently `null`; documented gap)
+- `condition` (fixed value: `new`)
+- `product_type` (internal category path)
+- `google_product_category` (rule-based mapping where confident)
+- `meta_fb_product_category` (rule-based mapping where confident)
 - `missing_fields` (explicit per-row gap visibility)
 
 ## Availability normalization
@@ -31,14 +34,42 @@ Availability is normalized using existing inventory rules:
 2. `in stock` when normalized quantity is greater than 0
 3. `out of stock` otherwise
 
+## Condition strategy
+
+For the current catalog phase, all products are exported with:
+
+- `condition = "new"`
+
+## Product type strategy
+
+`product_type` is generated from internal category names attached to each product.
+
+- Category names are normalized and sorted
+- Values are joined as a path using ` > `
+- Example: `Security > Cameras`
+
+## Category mapping strategy
+
+The export uses an explicit rule table in `shop/modeling/feed_export.py`:
+
+- Camera/PTZ/CCTV-like categories map to:
+  - Google: `Electronics > Video > Video Cameras`
+  - Meta: `Electronics > Cameras`
+- Sensor-like categories map to:
+  - Google: `Business & Industrial > Security & Surveillance > Sensors`
+  - Meta: `Electronics > Smart Home Devices`
+- Alarm/Siren-like categories map to:
+  - Google: `Home & Garden > Household Supplies > Alarm Systems`
+  - Meta: `Home Improvement > Home Security`
+
+If no rule confidently matches, mapping fields remain `null` and the product is listed under manual mapping gaps.
+
 ## Readiness gaps (blocking full Merchant/Meta readiness)
 
 The feed payload exposes global readiness gaps under `readiness_gaps`.
 Current known gaps:
 
-- `condition` source field is not stored on `Product`
 - `gtin_mpn` fields are missing
-- `google_product_category` mapping is missing
-- `meta_fb_product_category` mapping is missing
-
-These should be added in later iterations before direct API submissions.
+- products missing confident Google/Meta category mapping are listed in:
+  - `manual_category_mapping_products`
+  - `manual_category_mapping_product_types`

--- a/shop/modeling/feed_export.py
+++ b/shop/modeling/feed_export.py
@@ -2,6 +2,29 @@ from decimal import Decimal, InvalidOperation
 
 from ..models import Product
 
+# Explicit mapping table from internal category keywords to channel categories.
+# Keep this list small and readable so business owners can maintain it safely.
+#
+# google_product_category values use official Google taxonomy-style paths.
+# meta_fb_product_category values use readable Meta-facing category labels.
+_CATEGORY_MAPPING_RULES = [
+    {
+        "keywords": {"camera", "ptz", "cctv"},
+        "google_product_category": "Electronics > Video > Video Cameras",
+        "meta_fb_product_category": "Electronics > Cameras",
+    },
+    {
+        "keywords": {"sensor", "motion sensor"},
+        "google_product_category": "Business & Industrial > Security & Surveillance > Sensors",
+        "meta_fb_product_category": "Electronics > Smart Home Devices",
+    },
+    {
+        "keywords": {"alarm", "siren"},
+        "google_product_category": "Home & Garden > Household Supplies > Alarm Systems",
+        "meta_fb_product_category": "Home Improvement > Home Security",
+    },
+]
+
 
 def _primary_image(product):
     """
@@ -58,12 +81,52 @@ def _normalized_price(value):
         return None
 
 
+def _category_names(product):
+    """
+    Return normalized internal category names attached to this product.
+    """
+    return [
+        category.name.strip()
+        for category in product.category.all()
+        if (category.name or "").strip()
+    ]
+
+
+def _product_type_from_categories(product):
+    """
+    Build internal product_type from the store's own category path.
+    Current model has flat categories, so we produce a stable joined path.
+    """
+    names = sorted(_category_names(product), key=str.lower)
+    if not names:
+        return None
+    return " > ".join(names)
+
+
+def _find_category_mapping(product):
+    """
+    Map internal categories to Google + Meta categories using keyword rules.
+    Returns (google_category, meta_category) and leaves unknown cases unmapped.
+    """
+    haystack = " ".join(_category_names(product)).lower()
+    if not haystack:
+        return None, None
+
+    for rule in _CATEGORY_MAPPING_RULES:
+        if any(keyword in haystack for keyword in rule["keywords"]):
+            return rule["google_product_category"], rule["meta_fb_product_category"]
+
+    return None, None
+
+
 def product_feed_row(request, product):
     """
     Dedicated export row serializer for Merchant/Meta-ready catalog mapping.
     Kept separate from storefront serializers for backward compatibility.
     """
     description = (product.short_description or product.description or "").strip() or None
+
+    google_product_category, meta_fb_product_category = _find_category_mapping(product)
 
     row = {
         "id": str(product.id),
@@ -76,8 +139,11 @@ def product_feed_row(request, product):
         "availability": _normalized_availability(product),
         "brand": (product.brand or "").strip() or None,
         "sku": (product.sku or "").strip() or None,
-        # Condition has no model source yet, so we expose a null and mark it as a gap.
-        "condition": None,
+        # Business rule: all currently sold products are considered new condition.
+        "condition": "new",
+        "product_type": _product_type_from_categories(product),
+        "google_product_category": google_product_category,
+        "meta_fb_product_category": meta_fb_product_category,
     }
 
     row["missing_fields"] = [key for key, value in row.items() if value is None]
@@ -97,6 +163,28 @@ def build_product_feed_payload(request):
     Build a JSON-safe payload for internal feed testing.
     """
     rows = [product_feed_row(request, product) for product in product_feed_queryset()]
+    products_needing_manual_mapping = [
+        {
+            "id": row["id"],
+            "title": row["title"],
+            "product_type": row["product_type"],
+            "missing_category_fields": [
+                field
+                for field in ("google_product_category", "meta_fb_product_category")
+                if row.get(field) is None
+            ],
+        }
+        for row in rows
+        if row.get("google_product_category") is None or row.get("meta_fb_product_category") is None
+    ]
+    categories_needing_manual_mapping = sorted(
+        {
+            row["product_type"]
+            for row in products_needing_manual_mapping
+            if row.get("product_type")
+        }
+    )
+
     return {
         "fields": [
             "id",
@@ -110,12 +198,14 @@ def build_product_feed_payload(request):
             "brand",
             "sku",
             "condition",
+            "product_type",
+            "google_product_category",
+            "meta_fb_product_category",
         ],
         "products": rows,
         "readiness_gaps": {
-            "condition": "No source field exists on Product yet.",
             "gtin_mpn": "No GTIN/MPN fields exist yet (often required/recommended).",
-            "google_product_category": "No mapped Google product category field exists yet.",
-            "meta_fb_product_category": "No mapped Meta category field exists yet.",
+            "manual_category_mapping_products": products_needing_manual_mapping,
+            "manual_category_mapping_product_types": categories_needing_manual_mapping,
         },
     }

--- a/shop/modeling/feed_export.py
+++ b/shop/modeling/feed_export.py
@@ -1,0 +1,121 @@
+from decimal import Decimal, InvalidOperation
+
+from ..models import Product
+
+
+def _primary_image(product):
+    """
+    Return the first preferred product image object (thumbnail first) or None.
+    This stays internal so storefront serializers are not affected.
+    """
+    return product.images.filter(thumbnail=True).first() or product.images.first()
+
+
+def _absolute_product_url(request, product):
+    """
+    Build an absolute canonical URL for feed export rows.
+    """
+    return request.build_absolute_uri(product.get_absolute_url())
+
+
+def _absolute_image_url(request, product):
+    """
+    Build an absolute image URL when an image exists.
+    Returns None for products with no images (null-safe requirement).
+    """
+    image = _primary_image(product)
+    if not image:
+        return None
+    return request.build_absolute_uri(image.image.url)
+
+
+def _normalized_availability(product):
+    """
+    Normalize availability values for catalog feeds.
+    The rule intentionally mirrors existing inventory logic:
+    - preorder flag takes priority
+    - quantity > 0 => in stock
+    - otherwise out of stock
+    """
+    inventory = product.get_inventory_data()
+    if inventory["is_preorder"]:
+        return "preorder"
+    if inventory["in_stock"]:
+        return "in stock"
+    return "out of stock"
+
+
+def _normalized_price(value):
+    """
+    Serialize Decimal/number values to a 2-decimal string used by feed payloads.
+    Returns None for empty/invalid values so no fake values are emitted.
+    """
+    if value in (None, ""):
+        return None
+    try:
+        return f"{Decimal(value):.2f}"
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def product_feed_row(request, product):
+    """
+    Dedicated export row serializer for Merchant/Meta-ready catalog mapping.
+    Kept separate from storefront serializers for backward compatibility.
+    """
+    description = (product.short_description or product.description or "").strip() or None
+
+    row = {
+        "id": str(product.id),
+        "title": product.name,
+        "description": description,
+        "url": _absolute_product_url(request, product),
+        "image_url": _absolute_image_url(request, product),
+        "price": _normalized_price(product.sale_price or product.price),
+        "currency": (product.currency or "").strip() or None,
+        "availability": _normalized_availability(product),
+        "brand": (product.brand or "").strip() or None,
+        "sku": (product.sku or "").strip() or None,
+        # Condition has no model source yet, so we expose a null and mark it as a gap.
+        "condition": None,
+    }
+
+    row["missing_fields"] = [key for key, value in row.items() if value is None]
+    return row
+
+
+def product_feed_queryset():
+    """
+    Queryset used by feed export endpoint.
+    Limited to active products to match publicly listed catalog behavior.
+    """
+    return Product.objects.filter(active=True).prefetch_related("images")
+
+
+def build_product_feed_payload(request):
+    """
+    Build a JSON-safe payload for internal feed testing.
+    """
+    rows = [product_feed_row(request, product) for product in product_feed_queryset()]
+    return {
+        "fields": [
+            "id",
+            "title",
+            "description",
+            "url",
+            "image_url",
+            "price",
+            "currency",
+            "availability",
+            "brand",
+            "sku",
+            "condition",
+        ],
+        "products": rows,
+        "readiness_gaps": {
+            "condition": "No source field exists on Product yet.",
+            "gtin_mpn": "No GTIN/MPN fields exist yet (often required/recommended).",
+            "google_product_category": "No mapped Google product category field exists yet.",
+            "meta_fb_product_category": "No mapped Meta category field exists yet.",
+        },
+    }

--- a/shop/tests.py
+++ b/shop/tests.py
@@ -1,10 +1,14 @@
 from django.test import TestCase
 
-from .models import Product, ProductImage
+from .models import Categorie, Product, ProductImage
 
 
 class InternalProductFeedExportTests(TestCase):
     def setUp(self):
+        self.camera_category = Categorie.objects.create(
+            name="CCTV Camera",
+            description="Security camera products",
+        )
         self.product = Product.objects.create(
             name="Feed Ready Camera",
             price="149.99",
@@ -15,6 +19,7 @@ class InternalProductFeedExportTests(TestCase):
             brand="Doobara",
             sku="CAM-001",
         )
+        self.product.category.add(self.camera_category)
 
     def test_internal_feed_export_contains_required_fields(self):
         response = self.client.get("/internal/exports/products.json")
@@ -37,6 +42,9 @@ class InternalProductFeedExportTests(TestCase):
                 "brand",
                 "sku",
                 "condition",
+                "product_type",
+                "google_product_category",
+                "meta_fb_product_category",
             ],
         )
 
@@ -45,6 +53,16 @@ class InternalProductFeedExportTests(TestCase):
         self.assertEqual(product_row["title"], self.product.name)
         self.assertEqual(product_row["currency"], "USD")
         self.assertEqual(product_row["availability"], "in stock")
+        self.assertEqual(product_row["condition"], "new")
+        self.assertEqual(product_row["product_type"], "CCTV Camera")
+        self.assertEqual(
+            product_row["google_product_category"],
+            "Electronics > Video > Video Cameras",
+        )
+        self.assertEqual(
+            product_row["meta_fb_product_category"],
+            "Electronics > Cameras",
+        )
         self.assertIn("/products/", product_row["url"])
         self.assertTrue(product_row["url"].startswith("http://testserver/"))
 
@@ -65,4 +83,26 @@ class InternalProductFeedExportTests(TestCase):
     def test_internal_feed_export_exposes_missing_fields(self):
         response = self.client.get("/internal/exports/products.json")
         product_row = response.json()["products"][0]
-        self.assertIn("condition", product_row["missing_fields"])
+        self.assertNotIn("condition", product_row["missing_fields"])
+
+    def test_internal_feed_export_surfaces_unmapped_category_gaps(self):
+        unmapped_category = Categorie.objects.create(
+            name="Custom Bundle",
+            description="Internal-only grouping",
+        )
+        unmapped_product = Product.objects.create(
+            name="Unmapped Product",
+            price="299.99",
+            currency="USD",
+            active=True,
+            quantity=5,
+            availability="in stock",
+        )
+        unmapped_product.category.add(unmapped_category)
+
+        response = self.client.get("/internal/exports/products.json")
+        readiness_gaps = response.json()["readiness_gaps"]
+
+        self.assertIn("manual_category_mapping_products", readiness_gaps)
+        self.assertIn("manual_category_mapping_product_types", readiness_gaps)
+        self.assertIn("Custom Bundle", readiness_gaps["manual_category_mapping_product_types"])

--- a/shop/tests.py
+++ b/shop/tests.py
@@ -1,3 +1,68 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Product, ProductImage
+
+
+class InternalProductFeedExportTests(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            name="Feed Ready Camera",
+            price="149.99",
+            currency="USD",
+            active=True,
+            quantity=3,
+            availability="in stock",
+            brand="Doobara",
+            sku="CAM-001",
+        )
+
+    def test_internal_feed_export_contains_required_fields(self):
+        response = self.client.get("/internal/exports/products.json")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        self.assertIn("fields", payload)
+        self.assertIn("products", payload)
+        self.assertEqual(
+            payload["fields"],
+            [
+                "id",
+                "title",
+                "description",
+                "url",
+                "image_url",
+                "price",
+                "currency",
+                "availability",
+                "brand",
+                "sku",
+                "condition",
+            ],
+        )
+
+        product_row = payload["products"][0]
+        self.assertEqual(product_row["id"], str(self.product.id))
+        self.assertEqual(product_row["title"], self.product.name)
+        self.assertEqual(product_row["currency"], "USD")
+        self.assertEqual(product_row["availability"], "in stock")
+        self.assertIn("/products/", product_row["url"])
+        self.assertTrue(product_row["url"].startswith("http://testserver/"))
+
+    def test_internal_feed_export_image_url_is_null_safe(self):
+        response = self.client.get("/internal/exports/products.json")
+        product_row = response.json()["products"][0]
+        self.assertIsNone(product_row["image_url"])
+
+        ProductImage.objects.create(
+            product=self.product,
+            image="static/doobarashop/upload/images/feed-image.jpg",
+            thumbnail=True,
+        )
+        response_with_image = self.client.get("/internal/exports/products.json")
+        product_row_with_image = response_with_image.json()["products"][0]
+        self.assertIn("http://testserver/", product_row_with_image["image_url"])
+
+    def test_internal_feed_export_exposes_missing_fields(self):
+        response = self.client.get("/internal/exports/products.json")
+        product_row = response.json()["products"][0]
+        self.assertIn("condition", product_row["missing_fields"])

--- a/shop/urls.py
+++ b/shop/urls.py
@@ -20,5 +20,7 @@ urlpatterns=[
     # search keyword request
     path('search', views.search, name="search"),
     # order list filter request
-    path("orderby", views.orderby, name="orderby")
+    path("orderby", views.orderby, name="orderby"),
+    # Internal product feed export (JSON) for Merchant/Meta mapping QA.
+    path("internal/exports/products.json", views.internal_product_feed_export, name="internal_product_feed_export"),
 ]

--- a/shop/views.py
+++ b/shop/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from .models import *
 from django.urls import reverse
@@ -9,6 +10,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 # Created modules to manage shop page functions
 from .modeling.serialize_helper import *
 from .modeling.filter_helper import *
+from .modeling.feed_export import build_product_feed_payload
 
 _JSON_SCRIPT_ESCAPES = {
     ord(">"): "\\u003E",
@@ -283,6 +285,15 @@ def orderby(request):
         return _shop_page_response(request, slop)
 
     return _shop_page_response(request, [])
+
+
+def internal_product_feed_export(request):
+    """
+    Internal JSON export endpoint for catalog feed QA.
+    This is intentionally read-only and API-integration free.
+    """
+    payload = build_product_feed_payload(request)
+    return JsonResponse(payload)
 
 
 # request -> render(url)


### PR DESCRIPTION
### Motivation

- Provide a clean, dedicated product feed/export layer for future Google Merchant and Meta catalog mapping without touching storefront rendering or adding third-party API integrations. 
- Keep feed logic explicit and separate to preserve backward compatibility and make gaps visible for later work. 
- Normalize availability, canonical URLs, and image handling so the payload is suitable for downstream mapping. 

### Description

- Added a new feed helper `shop/modeling/feed_export.py` that builds per-product rows with normalized `id`, `title`, `description`, `url`, `image_url`, `price`, `currency`, `availability`, `brand`, `sku`, `condition` (currently `null`) and a `missing_fields` list. 
- Implemented canonical absolute URL and absolute/null-safe image URL builders, normalized availability logic (preorder > in stock > out of stock), and a safe price serializer in `feed_export.py`. 
- Exposed an internal, read-only JSON endpoint `internal_product_feed_export` (view) wired to `GET /internal/exports/products.json` (route in `shop/urls.py`) that returns the feed payload and a `readiness_gaps` summary; no Google/Meta API integration or storefront changes were made. 
- Added documentation `docs/catalog-feed-readiness.md` describing fields, normalization rules, and known readiness gaps, and added unit tests `InternalProductFeedExportTests` in `shop/tests.py` that assert required fields, null-safe image URLs, absolute canonical URLs, and explicit missing-field exposure. 

### Testing

- Ran code compilation with `python -m compileall shop/modeling/feed_export.py shop/views.py shop/urls.py shop/tests.py`, which succeeded. 
- Attempted `python manage.py test shop.tests` but the run failed in this environment because `SECRET_KEY` is not set and the test database `NAME` is not configured, preventing automated test execution here. 
- Added unit tests (`InternalProductFeedExportTests`) that should pass in a correctly configured environment and exercise required-field coverage, image null-safety, and missing-field reporting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02e5a8db883249da27e06170bc2cc)