### PR TITLE
Enhance Django admin for shop and users: inlines, image previews, filters, and custom UserAdmin

### DIFF
--- a/shop/admin.py
+++ b/shop/admin.py
@@ -1,22 +1,262 @@
 from django.contrib import admin
-from .models import *
-
+from django.utils.html import format_html
 from import_export.admin import ImportExportActionModelAdmin
 
+from .models import (
+    Categorie,
+    Hero_Card,
+    Product,
+    ProductImage,
+    ProductVariant,
+    ProductVariantImage,
+    ProductVariantItem,
+)
+
+
+class ProductImageInline(admin.TabularInline):
+    model = ProductImage
+    extra = 1
+    fields = ("image", "image_preview", "alt_text", "thumbnail")
+    readonly_fields = ("image_preview",)
+
+    def image_preview(self, obj):
+        if obj and obj.image:
+            return format_html(
+                '<img src="{}" style="max-height: 70px; border-radius: 4px;" />',
+                obj.image.url,
+            )
+        return "-"
+
+    image_preview.short_description = "Preview"
+
+
+class ProductVariantInline(admin.TabularInline):
+    model = ProductVariant
+    extra = 0
+    fields = (
+        "title",
+        "tier",
+        "price",
+        "sale_price",
+        "quantity",
+        "active",
+        "is_default",
+        "sort_order",
+    )
+    show_change_link = True
+
+
+class ProductVariantImageInline(admin.TabularInline):
+    model = ProductVariantImage
+    extra = 1
+    fields = ("image", "image_preview", "alt_text", "thumbnail")
+    readonly_fields = ("image_preview",)
+
+    def image_preview(self, obj):
+        if obj and obj.image:
+            return format_html(
+                '<img src="{}" style="max-height: 70px; border-radius: 4px;" />',
+                obj.image.url,
+            )
+        return "-"
+
+    image_preview.short_description = "Preview"
+
+
+@admin.register(Product)
 class ProductAdmin(ImportExportActionModelAdmin):
-    list_display = ("name", "slug", "brand", "sku", "price", "active", "featured")
-    search_fields = ("name", "slug", "brand", "sku")
+    list_display = (
+        "name",
+        "slug",
+        "brand",
+        "sku",
+        "price",
+        "quantity",
+        "active",
+        "featured",
+        "updated_time",
+    )
+    search_fields = ("name", "slug", "sku", "brand")
+    list_filter = ("active", "featured", "availability", "stock", "category")
+    ordering = ("-updated_time", "name")
+    readonly_fields = ("created_time", "updated_time")
     prepopulated_fields = {"slug": ("name",)}
+    filter_horizontal = ("category",)
+    inlines = (ProductImageInline, ProductVariantInline)
+    fieldsets = (
+        (
+            "Basic info",
+            {
+                "fields": (
+                    "name",
+                    "slug",
+                    "brand",
+                    "sku",
+                    "active",
+                    "featured",
+                    "is_system",
+                )
+            },
+        ),
+        (
+            "Pricing",
+            {
+                "fields": (
+                    "price",
+                    "sale_price",
+                    "currency",
+                )
+            },
+        ),
+        (
+            "Inventory",
+            {
+                "fields": (
+                    "stock",
+                    "quantity",
+                    "availability",
+                    "variant",
+                    "variant_name",
+                    "variant_default",
+                )
+            },
+        ),
+        (
+            "Content",
+            {
+                "fields": (
+                    "short_description",
+                    "description",
+                    "video",
+                )
+            },
+        ),
+        (
+            "Shipping",
+            {
+                "fields": (
+                    "weight",
+                    "dimensions",
+                )
+            },
+        ),
+        (
+            "Categories",
+            {
+                "fields": ("category",),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "fields": ("created_time", "updated_time"),
+            },
+        ),
+    )
 
 
-class ShopModelAdmin(ImportExportActionModelAdmin):
-    pass
+@admin.register(ProductVariant)
+class ProductVariantAdmin(ImportExportActionModelAdmin):
+    list_display = (
+        "title",
+        "product",
+        "tier",
+        "price",
+        "quantity",
+        "active",
+        "is_default",
+        "sort_order",
+    )
+    search_fields = ("title", "product__name", "product__sku")
+    list_filter = ("active", "tier", "currency", "is_default")
+    ordering = ("product__name", "sort_order", "title")
+    inlines = (ProductVariantImageInline,)
+    fieldsets = (
+        (
+            "Variant",
+            {
+                "fields": (
+                    "product",
+                    "title",
+                    "tier",
+                    "active",
+                    "is_default",
+                    "sort_order",
+                )
+            },
+        ),
+        (
+            "Pricing",
+            {
+                "fields": (
+                    "price",
+                    "sale_price",
+                    "currency",
+                )
+            },
+        ),
+        (
+            "Inventory",
+            {
+                "fields": (
+                    "stock",
+                    "quantity",
+                )
+            },
+        ),
+        (
+            "Description",
+            {
+                "fields": ("short_description", "description"),
+            },
+        ),
+    )
 
-# Register your models here.
-admin.site.register(Categorie, ShopModelAdmin)
-admin.site.register(Product, ProductAdmin)
-admin.site.register(ProductImage, ShopModelAdmin)
-admin.site.register(ProductVariant, ShopModelAdmin)
-admin.site.register(ProductVariantImage, ShopModelAdmin)
-admin.site.register(ProductVariantItem, ShopModelAdmin)
-admin.site.register(Hero_Card, ShopModelAdmin)
+
+@admin.register(ProductImage)
+class ProductImageAdmin(ImportExportActionModelAdmin):
+    list_display = ("product", "alt_text", "thumbnail")
+    search_fields = ("product__name", "product__sku", "alt_text")
+    list_filter = ("thumbnail",)
+    ordering = ("product__name", "id")
+
+
+@admin.register(ProductVariantImage)
+class ProductVariantImageAdmin(ImportExportActionModelAdmin):
+    list_display = ("variant", "variant_product", "alt_text", "thumbnail")
+    search_fields = ("variant__title", "variant__product__name", "alt_text")
+    list_filter = ("thumbnail",)
+    ordering = ("variant__product__name", "variant__title", "id")
+
+    def variant_product(self, obj):
+        return obj.variant.product
+
+    variant_product.short_description = "Product"
+
+
+@admin.register(Categorie)
+class CategoryAdmin(ImportExportActionModelAdmin):
+    list_display = ("name", "short_description")
+    search_fields = ("name", "description")
+    ordering = ("name",)
+
+    def short_description(self, obj):
+        if len(obj.description) <= 80:
+            return obj.description
+        return f"{obj.description[:77]}..."
+
+    short_description.short_description = "Description"
+
+
+@admin.register(ProductVariantItem)
+class ProductVariantItemAdmin(ImportExportActionModelAdmin):
+    list_display = ("variant", "included_product", "quantity")
+    search_fields = ("variant__title", "variant__product__name", "included_product__name")
+    list_filter = ("variant__product",)
+
+
+@admin.register(Hero_Card)
+class HeroCardAdmin(ImportExportActionModelAdmin):
+    list_display = ("title", "tag", "price", "active")
+    search_fields = ("title", "tag", "categorie")
+    list_filter = ("active",)

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,11 +1,129 @@
 from django.contrib import admin
-from .models import *
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
 
-# Register your models here.
-admin.site.register(Delivery_Address_Details)
+from .models import Delivery_Address_Details, Item_Order, Orders
+
+
+class ItemOrderInline(admin.TabularInline):
+    model = Item_Order
+    extra = 0
+    fields = ("product_name", "product", "price", "quantity")
+    readonly_fields = ("product_name", "product", "price", "quantity")
+    can_delete = False
+
+
+@admin.register(Delivery_Address_Details)
+class DeliveryAddressAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "user",
+        "name",
+        "last_name",
+        "city_town",
+        "phone_number",
+        "default",
+    )
+    search_fields = (
+        "user__username",
+        "user__email",
+        "name",
+        "last_name",
+        "phone_number",
+        "city_town",
+    )
+    list_filter = ("default", "city_town")
+    ordering = ("user__username", "id")
+
+
 @admin.register(Orders)
 class OrdersAdmin(admin.ModelAdmin):
-    list_display = ('id', 'user', 'status', 'total', 'shipping_label', 'shipping_price', 'date')  # Add 'date' here
-    list_filter = ('status', 'date')  # Optional: Add filters for status and date
-    search_fields = ('user__username', 'status')  # Optional: Add search functionality
-admin.site.register(Item_Order)
+    list_display = (
+        "id",
+        "user",
+        "total",
+        "status",
+        "date",
+        "shipping_label",
+        "shipping_price",
+    )
+    list_filter = ("status", "date", "currency", "shipping_label")
+    search_fields = (
+        "id",
+        "user__username",
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+        "address__phone_number",
+        "address__name",
+        "address__last_name",
+    )
+    ordering = ("-date",)
+    readonly_fields = ("id", "date")
+    inlines = (ItemOrderInline,)
+    fieldsets = (
+        (
+            "Order",
+            {
+                "fields": (
+                    "id",
+                    "status",
+                    "date",
+                )
+            },
+        ),
+        (
+            "Customer",
+            {
+                "fields": (
+                    "user",
+                    "address",
+                )
+            },
+        ),
+        (
+            "Amounts",
+            {
+                "fields": (
+                    "total",
+                    "currency",
+                    "shipping_method",
+                    "shipping_label",
+                    "shipping_price",
+                )
+            },
+        ),
+        (
+            "Notes",
+            {
+                "fields": ("note",),
+            },
+        ),
+    )
+
+
+@admin.register(Item_Order)
+class ItemOrderAdmin(admin.ModelAdmin):
+    list_display = ("id", "order", "product_name", "price", "quantity")
+    search_fields = ("order__id", "product_name", "product__name")
+    list_filter = ("order__status",)
+    ordering = ("-order__date", "id")
+
+
+class DoobaraUserAdmin(UserAdmin):
+    list_display = (
+        "username",
+        "first_name",
+        "last_name",
+        "email",
+        "is_active",
+        "is_staff",
+        "date_joined",
+    )
+    search_fields = ("username", "first_name", "last_name", "email")
+    list_filter = ("is_active", "is_staff", "is_superuser", "date_joined")
+    ordering = ("-date_joined",)
+
+
+admin.site.unregister(User)
+admin.site.register(User, DoobaraUserAdmin)


### PR DESCRIPTION
### Motivation
- Improve the Django admin UX and manageability for the shop app by adding image previews, inlines, more helpful list displays and filters, and organized fieldsets for product-related models.
- Standardize admin registrations and remove wildcard imports to make admin code clearer and safer.
- Customize the user/admin experience to surface order and address data directly and provide a tailored `User` admin listing.

### Description
- Reworked `shop/admin.py` to import models explicitly, added `ProductImageInline`, `ProductVariantInline`, and `ProductVariantImageInline` with an `image_preview` using `format_html`, and converted model registrations to `@admin.register` classes including `ProductAdmin`, `ProductVariantAdmin`, `ProductImageAdmin`, `ProductVariantImageAdmin`, `ProductVariantItemAdmin`, `CategoryAdmin`, and `HeroCardAdmin` with improved `list_display`, `search_fields`, `list_filter`, `ordering`, and `fieldsets` and added `filter_horizontal` and `readonly_fields` where appropriate.
- Reworked `users/admin.py` to add `ItemOrderInline`, `DeliveryAddressAdmin`, `OrdersAdmin` with inlines and extended search/filters/fieldsets, `ItemOrderAdmin`, and a custom `DoobaraUserAdmin` replacing the default `User` admin by calling `admin.site.unregister(User)` and `admin.site.register(User, DoobaraUserAdmin)`.
- Replaced wildcard imports with explicit imports and continued to use `ImportExportActionModelAdmin` for models that support import/export features.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03c0a36108324b03387163814de75)