### PR TITLE
Enforce single thumbnail/default-variant constraints; add admin validation and stock sync

### DIFF
--- a/shop/admin.py
+++ b/shop/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django import forms
 from import_export.admin import ImportExportActionModelAdmin
 
 from .models import (
@@ -63,8 +64,37 @@ class ProductVariantImageInline(admin.TabularInline):
     image_preview.short_description = "Preview"
 
 
+class ProductAdminForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        fields = "__all__"
+        help_texts = {
+            "quantity": (
+                "Inventory source of truth. Quantity > 0 = in stock. "
+                "Quantity <= 0 = out of stock."
+            ),
+            "availability": (
+                "Use Preorder only for products you intentionally sell before stock arrives. "
+                "For normal inventory, availability is auto-aligned from quantity."
+            ),
+        }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        quantity = cleaned_data.get("quantity") or 0
+        availability = cleaned_data.get("availability")
+
+        # Keep preorder as an explicit operator choice and auto-align
+        # normal availability values from quantity to prevent conflicts.
+        if availability != "preorder":
+            cleaned_data["availability"] = "in stock" if quantity > 0 else "out of stock"
+
+        return cleaned_data
+
+
 @admin.register(Product)
 class ProductAdmin(ImportExportActionModelAdmin):
+    form = ProductAdminForm
     list_display = (
         "name",
         "slug",
@@ -79,7 +109,7 @@ class ProductAdmin(ImportExportActionModelAdmin):
     search_fields = ("name", "slug", "sku", "brand")
     list_filter = ("active", "featured", "availability", "stock", "category")
     ordering = ("-updated_time", "name")
-    readonly_fields = ("created_time", "updated_time")
+    readonly_fields = ("stock", "created_time", "updated_time")
     prepopulated_fields = {"slug": ("name",)}
     filter_horizontal = ("category",)
     inlines = (ProductImageInline, ProductVariantInline)
@@ -94,7 +124,6 @@ class ProductAdmin(ImportExportActionModelAdmin):
                     "sku",
                     "active",
                     "featured",
-                    "is_system",
                 )
             },
         ),
@@ -112,12 +141,12 @@ class ProductAdmin(ImportExportActionModelAdmin):
             "Inventory",
             {
                 "fields": (
-                    "stock",
                     "quantity",
                     "availability",
                     "variant",
                     "variant_name",
                     "variant_default",
+                    "stock",
                 )
             },
         ),
@@ -147,12 +176,25 @@ class ProductAdmin(ImportExportActionModelAdmin):
             },
         ),
         (
+            "Advanced/internal",
+            {
+                "classes": ("collapse",),
+                "fields": ("is_system",),
+            },
+        ),
+        (
             "Timestamps",
             {
                 "fields": ("created_time", "updated_time"),
             },
         ),
     )
+
+    def save_model(self, request, obj, form, change):
+        # Stock is a derived flag in admin: quantity > 0 means in stock.
+        quantity = obj.quantity or 0
+        obj.stock = quantity > 0
+        super().save_model(request, obj, form, change)
 
 
 @admin.register(ProductVariant)

--- a/shop/migrations/0028_productvariant_single_default_per_product.py
+++ b/shop/migrations/0028_productvariant_single_default_per_product.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+def dedupe_default_variants(apps, schema_editor):
+    # Before adding the unique constraint, keep one default variant per
+    # product and unset any extra defaults to avoid migration failure.
+    ProductVariant = apps.get_model("shop", "ProductVariant")
+
+    duplicate_product_ids = (
+        ProductVariant.objects.filter(is_default=True)
+        .values_list("product_id", flat=True)
+    )
+
+    seen = set()
+    for product_id in duplicate_product_ids:
+        if product_id in seen:
+            continue
+        seen.add(product_id)
+
+        defaults_qs = ProductVariant.objects.filter(
+            product_id=product_id,
+            is_default=True,
+        ).order_by("sort_order", "id")
+        # Keep the first by business-friendly order, unset the rest.
+        keep = defaults_qs.first()
+        if not keep:
+            continue
+        defaults_qs.exclude(pk=keep.pk).update(is_default=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shop", "0027_product_brand_product_sku_product_slug"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            dedupe_default_variants,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="productvariant",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(is_default=True),
+                fields=("product",),
+                name="shop_one_default_variant_per_product",
+            ),
+        ),
+    ]

--- a/shop/migrations/0029_image_single_thumbnail_constraints.py
+++ b/shop/migrations/0029_image_single_thumbnail_constraints.py
@@ -1,0 +1,79 @@
+from django.db import migrations, models
+
+
+def dedupe_product_thumbnails(apps, schema_editor):
+    # Normalize existing data so each product has at most one thumbnail
+    # before the DB constraint is added.
+    ProductImage = apps.get_model("shop", "ProductImage")
+
+    product_ids = (
+        ProductImage.objects.filter(thumbnail=True)
+        .values_list("product_id", flat=True)
+        .distinct()
+    )
+    for product_id in product_ids:
+        thumbs_qs = ProductImage.objects.filter(
+            product_id=product_id,
+            thumbnail=True,
+        ).order_by("id")
+        # Keep the oldest thumbnail and unset all others.
+        keep = thumbs_qs.first()
+        if not keep:
+            continue
+        thumbs_qs.exclude(pk=keep.pk).update(thumbnail=False)
+
+
+def dedupe_variant_thumbnails(apps, schema_editor):
+    # Normalize existing data so each variant has at most one thumbnail
+    # before the DB constraint is added.
+    ProductVariantImage = apps.get_model("shop", "ProductVariantImage")
+
+    variant_ids = (
+        ProductVariantImage.objects.filter(thumbnail=True)
+        .values_list("variant_id", flat=True)
+        .distinct()
+    )
+    for variant_id in variant_ids:
+        thumbs_qs = ProductVariantImage.objects.filter(
+            variant_id=variant_id,
+            thumbnail=True,
+        ).order_by("id")
+        # Keep the oldest thumbnail and unset all others.
+        keep = thumbs_qs.first()
+        if not keep:
+            continue
+        thumbs_qs.exclude(pk=keep.pk).update(thumbnail=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shop", "0028_productvariant_single_default_per_product"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            dedupe_product_thumbnails,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            dedupe_variant_thumbnails,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="productimage",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(thumbnail=True),
+                fields=("product",),
+                name="shop_one_product_thumbnail_per_product",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="productvariantimage",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(thumbnail=True),
+                fields=("variant",),
+                name="shop_one_variant_thumbnail_per_variant",
+            ),
+        ),
+    ]

--- a/shop/models.py
+++ b/shop/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.exceptions import ValidationError
 from .modeling.serialize_helper import *
 from django.dispatch import receiver
 from django.urls import reverse
@@ -235,10 +236,34 @@ class ProductImage(models.Model):
     # if true the image is the main image for the product 
     thumbnail = models.BooleanField(default=False)  # True if this is a thumbnail image
 
+    class Meta:
+        constraints = [
+            # Enforce at DB level: only one thumbnail=True row per product.
+            models.UniqueConstraint(
+                fields=["product"],
+                condition=models.Q(thumbnail=True),
+                name="shop_one_product_thumbnail_per_product",
+            ),
+        ]
 
     # data to show on admin page 
     def __str__(self):
         return f"{self.product.name} - {self.alt_text}" 
+
+    def clean(self):
+        super().clean()
+        if not self.thumbnail or not self.product_id:
+            return
+
+        # Provide early, user-friendly admin/form error before DB constraint.
+        duplicate_thumbnail_exists = ProductImage.objects.filter(
+            product_id=self.product_id,
+            thumbnail=True,
+        ).exclude(pk=self.pk).exists()
+        if duplicate_thumbnail_exists:
+            raise ValidationError(
+                {"thumbnail": "Only one thumbnail image is allowed per product."}
+            )
 
 class ProductVariant(models.Model):
     product = models.ForeignKey("Product", related_name="variants", on_delete=models.CASCADE)
@@ -261,9 +286,32 @@ class ProductVariant(models.Model):
             # product filter + active filter + sort by sort_order.
             models.Index(fields=["product", "active", "sort_order"], name="shop_var_prod_act_sort_idx"),
         ]
+        constraints = [
+            # Enforce at DB level: only one default variant per product.
+            models.UniqueConstraint(
+                fields=["product"],
+                condition=models.Q(is_default=True),
+                name="shop_one_default_variant_per_product",
+            ),
+        ]
 
     def __str__(self):
         return f"{self.product.name} - {self.title}"
+
+    def clean(self):
+        super().clean()
+        if not self.is_default or not self.product_id:
+            return
+
+        # Provide early, user-friendly admin/form error before DB constraint.
+        duplicate_default_exists = ProductVariant.objects.filter(
+            product_id=self.product_id,
+            is_default=True,
+        ).exclude(pk=self.pk).exists()
+        if duplicate_default_exists:
+            raise ValidationError(
+                {"is_default": "Only one default variant is allowed per product."}
+            )
 
     @property
     def normalized_quantity(self):
@@ -304,8 +352,33 @@ class ProductVariantImage(models.Model):
     image = models.ImageField(upload_to="static/doobarashop/upload/images")
     thumbnail = models.BooleanField(default=False)
 
+    class Meta:
+        constraints = [
+            # Enforce at DB level: only one thumbnail=True row per variant.
+            models.UniqueConstraint(
+                fields=["variant"],
+                condition=models.Q(thumbnail=True),
+                name="shop_one_variant_thumbnail_per_variant",
+            ),
+        ]
+
     def __str__(self):
         return f"{self.variant.product.name} - {self.variant.title} - {self.alt_text}"
+
+    def clean(self):
+        super().clean()
+        if not self.thumbnail or not self.variant_id:
+            return
+
+        # Provide early, user-friendly admin/form error before DB constraint.
+        duplicate_thumbnail_exists = ProductVariantImage.objects.filter(
+            variant_id=self.variant_id,
+            thumbnail=True,
+        ).exclude(pk=self.pk).exists()
+        if duplicate_thumbnail_exists:
+            raise ValidationError(
+                {"thumbnail": "Only one thumbnail image is allowed per variant."}
+            )
 
 class ProductVariantItem(models.Model):
     variant = models.ForeignKey("ProductVariant", related_name="package_items", on_delete=models.CASCADE)


### PR DESCRIPTION
### Motivation

- Prevent data integrity issues by ensuring only one thumbnail per product/variant and only one default variant per product at the database level.
- Surface early, user-friendly validation errors in forms/admin to avoid DB constraint failures during edits.
- Make admin inventory behavior explicit by keeping `stock` derived from `quantity` and aligning `availability` automatically.

### Description

- Added DB-level `UniqueConstraint`s to `ProductImage`, `ProductVariantImage`, and `ProductVariant` to enforce a single `thumbnail=True` per product/variant and a single `is_default=True` per product, and added `clean()` methods that raise `ValidationError` for duplicates before hitting the DB.
- Introduced two migrations `0028_productvariant_single_default_per_product.py` and `0029_image_single_thumbnail_constraints.py` that run normalization steps to unset extra defaults/thumbnails and then add the unique constraints.
- Added `ProductAdminForm` with help texts and a `clean()` override to auto-align `availability` from `quantity` unless `preorder` is explicitly chosen, and wired it into `ProductAdmin` as `form`.
- Updated `ProductAdmin` to include `stock` as a readonly field, moved `is_system` into a collapsed "Advanced/internal" fieldset, and implemented `save_model` to set `stock = quantity > 0` before saving.

### Testing

- Ran the Django test suite with `python manage.py test`, and the tests completed successfully.
- Executed migration normalization and application locally via `python manage.py migrate` (including the two new migrations) and confirmed the migration operations applied without errors.
- Performed admin form validation checks by creating/updating products, variants, and images in the admin UI to verify `clean()` errors and `stock`/`availability` behavior (manual form-driven checks accompanying automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0400a12dc83248dc266d61a391080)