### PR TITLE
Add minimal normal-product variant selector on product detail page

### DIFF
--- a/cart/models.py
+++ b/cart/models.py
@@ -55,7 +55,8 @@ class Cart_Item (models.Model):
     # object -> dict
     # convert object specified keys to a dict key/value
     def serialize(self):
-        target_name = self.variant.title if self.variant else self.product.name
+        # Keep cart line item labels explicit so selected variants are clear to the customer.
+        target_name = f"{self.product.name} — {self.variant.title}" if self.variant else self.product.name
         target_price = self.variant.sale_price if self.variant and self.variant.sale_price else (self.variant.price if self.variant else self.product.price)
         target_currency = self.variant.currency if self.variant else self.product.currency
         if self.variant:

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -136,6 +136,20 @@
     color: var.$ui-primary;
 }
 
+.single-product-compare-price {
+    margin: 4px 0 0;
+    color: #64748b;
+    font-size: 0.92rem;
+}
+
+.single-product-compare-price span {
+    text-decoration: line-through;
+}
+
+.single-product-compare-price.is-hidden {
+    display: none;
+}
+
 .single-product-availability {
     margin: 0 0 10px;
     font-size: 0.9rem;

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -55,6 +55,7 @@
                         <button
                             id="spatc"
                             class="single-product-addtocart shop-add-to-cart"
+                            data-cart-handler="system"
                             data-variant-id="{{ default_variant.id }}"
                             data-ga-item-id="{{ default_variant.id }}"
                             data-ga-item-name="{{ default_variant.title|escapejs }}"
@@ -89,7 +90,7 @@
                         {% endif %}
                     </div>
 
-                    <div class="single-product-gallery__thumbs">
+                    <div class="single-product-gallery__thumbs" id="normal-variant-gallery">
                         {% for image in product.all_images %}
                                 <button type="button" class="single-product-thumb">
                                     <img class="sp-thumb-image"
@@ -108,27 +109,24 @@
                     <div class="single-product-price-row">
                         <div class="single-product-price-wrap">
                             <span class="single-product-price-label">Price</span>
-                            <p class="single-product-availability {% if product.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}">
-                                {{ product.availability_label }}
+                            <p id="normal-variant-availability" class="single-product-availability {% if default_normal_variant %}{% if default_normal_variant.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}{% else %}{% if product.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}{% endif %}">
+                                {% if default_normal_variant %}{{ default_normal_variant.availability_label }}{% else %}{{ product.availability_label }}{% endif %}
                             </p>
-                            <h2 id="spp" class="single-product-price">$ {{ product.price|floatformat:2 }}</h2>
+                            <h2 id="spp" class="single-product-price">$ {% if default_normal_variant %}{% if default_normal_variant.sale_price %}{{ default_normal_variant.sale_price|floatformat:2 }}{% else %}{{ default_normal_variant.price|floatformat:2 }}{% endif %}{% else %}{{ product.price|floatformat:2 }}{% endif %}</h2>
+                            <p id="normal-variant-compare-price" class="single-product-compare-price {% if not default_normal_variant or not default_normal_variant.sale_price %}is-hidden{% endif %}">
+                                {% if default_normal_variant and default_normal_variant.sale_price %}<span>$ {{ default_normal_variant.price|floatformat:2 }}</span>{% endif %}
+                            </p>
                         </div>
                     </div>
 
-                    {% if product.variant_options %}
+                    {% if normal_variants %}
                         <div class="single-product-variant">
                             <label for="variants">Choose Variant</label>
                             <select name="variant" id="variants">
-                                {% for var in product.variant_options %}
-                                    {% if var.default %}
-                                        <option selected="selected" class="svoption" value="{{ var }}">
-                                            {{ var.title }}
-                                        </option>
-                                    {% else %}
-                                        <option class="svoption" value="{{ var }}">
-                                            {{ var.title }}
-                                        </option>
-                                    {% endif %}
+                                {% for var in normal_variants %}
+                                    <option class="svoption" value="{{ var.id }}" {% if default_normal_variant and default_normal_variant.id == var.id %}selected="selected"{% endif %}>
+                                        {{ var.title }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -143,13 +141,14 @@
                         <button id="spatc"
                                 class="single-product-addtocart shop-add-to-cart"
                                 value="{{ product.pid }}"
-                                data-ga-item-id="{{ product.id }}"
-                                data-ga-item-name="{{ product.title|escapejs }}"
-                                data-ga-price="{{ product.price|floatformat:2 }}"
-                                data-ga-currency="{{ product.currency|default:'USD' }}"
+                                {% if default_normal_variant %}data-variant-id="{{ default_normal_variant.id }}"{% endif %}
+                                data-ga-item-id="{% if default_normal_variant %}{{ default_normal_variant.id }}{% else %}{{ product.id }}{% endif %}"
+                                data-ga-item-name="{% if default_normal_variant %}{{ default_normal_variant.title|escapejs }}{% else %}{{ product.title|escapejs }}{% endif %}"
+                                data-ga-price="{% if default_normal_variant %}{% if default_normal_variant.sale_price %}{{ default_normal_variant.sale_price|floatformat:2 }}{% else %}{{ default_normal_variant.price|floatformat:2 }}{% endif %}{% else %}{{ product.price|floatformat:2 }}{% endif %}"
+                                data-ga-currency="{% if default_normal_variant and default_normal_variant.currency %}{{ default_normal_variant.currency }}{% else %}{{ product.currency|default:'USD' }}{% endif %}"
                                 data-ga-item-category="{% if product.pcategory.0 %}{{ product.pcategory.0.name|escapejs }}{% endif %}"
-                                {% if not product.can_purchase %}disabled{% endif %}>
-                            {{ product.cart_cta_label|default:"Out of Stock" }}
+                                {% if default_normal_variant %}{% if not default_normal_variant.can_purchase %}disabled{% endif %}{% else %}{% if not product.can_purchase %}disabled{% endif %}{% endif %}>
+                            {% if default_normal_variant %}{{ default_normal_variant.cart_cta_label|default:"Out of Stock" }}{% else %}{{ product.cart_cta_label|default:"Out of Stock" }}{% endif %}
                         </button>
                     </div>
 
@@ -162,15 +161,26 @@
                     <div class="single-product-specs">
                         <h3>Specifications</h3>
                         <div class="single-product-specs__content">
-                            <ul class="single-product-spec-list">
-                                {% for line in product.pshortdescription %}
-                                <li>{{ line }}</li>
-                                {% endfor %}
+                            <ul class="single-product-spec-list" id="normal-variant-short-specs">
+                                {% if default_normal_variant and default_normal_variant.short_description_lines %}
+                                    {% for line in default_normal_variant.short_description_lines %}
+                                    <li>{{ line }}</li>
+                                    {% endfor %}
+                                {% else %}
+                                    {% for line in product.pshortdescription %}
+                                    <li>{{ line }}</li>
+                                    {% endfor %}
+                                {% endif %}
                             </ul>
                         </div>
                     </div>
                 </div>
             </div>
+            {% if normal_variants %}
+                {# JSON payload for normal-product variant switching on the same canonical URL. #}
+                {{ normal_variants|json_script:"normal-variant-data" }}
+                {{ default_normal_variant.id|default:0|json_script:"default-normal-variant-id" }}
+            {% endif %}
         {% endif %}
 
         {% if product.pvideo %}
@@ -203,7 +213,11 @@
                     <h2>Description</h2>
                 </div>
                 <div class="single-product-richtext" id="longdescription">
-                    {{ product.plongdescription|safe }}
+                    {% if default_normal_variant and default_normal_variant.description %}
+                        {{ default_normal_variant.description|safe }}
+                    {% else %}
+                        {{ product.plongdescription|safe }}
+                    {% endif %}
                 </div>
             </div>
 

--- a/shop/views.py
+++ b/shop/views.py
@@ -173,73 +173,117 @@ def single_product(request, locat=None, slug=None):
     # given product name, prodcut object serialized dict (using models)
     product = parent_product.serialize("all")
 
-    variants_qs = (
-        parent_product.variants.filter(active=True)
-        .prefetch_related("images", "package_items__included_product__images")
-        .order_by("sort_order")
-    )
+    # Keep system bundle/tier flow and normal product variant flow isolated so
+    # existing system logic remains unchanged.
+    variants_qs = parent_product.variants.filter(active=True).prefetch_related("images")
+    system_variants = []
+    default_system_variant = None
+    normal_variants = []
+    default_normal_variant = None
 
-    tier_priority = {"advanced": 0, "basic": 1, "pro": 2}
-    variants = []
-    default_variant = None
+    if parent_product.is_system:
+        variants_qs = variants_qs.prefetch_related("package_items__included_product__images").order_by("sort_order")
+        tier_priority = {"advanced": 0, "basic": 1, "pro": 2}
 
-    for variant in variants_qs:
-        variant_inventory = variant.get_inventory_data()
-        thumb = variant.images.filter(thumbnail=True).first() or variant.images.first()
-        images = [
-            {"url": image.image.url, "alt_text": image.alt_text}
-            for image in variant.images.all()
-        ]
-        package_items = []
-        for package_item in variant.package_items.all():
-            included_thumb = package_item.included_product.images.filter(thumbnail=True).first() or package_item.included_product.images.first()
-            package_items.append(
-                {
-                    "name": package_item.included_product.name,
-                    "url": package_item.included_product.get_absolute_url(),
-                    "qty": package_item.quantity,
-                    "thumbnail": included_thumb.image.url if included_thumb else None,
-                }
-            )
+        for variant in variants_qs:
+            variant_inventory = variant.get_inventory_data()
+            thumb = variant.images.filter(thumbnail=True).first() or variant.images.first()
+            images = [
+                {"url": image.image.url, "alt_text": image.alt_text}
+                for image in variant.images.all()
+            ]
+            package_items = []
+            for package_item in variant.package_items.all():
+                included_thumb = package_item.included_product.images.filter(thumbnail=True).first() or package_item.included_product.images.first()
+                package_items.append(
+                    {
+                        "name": package_item.included_product.name,
+                        "url": package_item.included_product.get_absolute_url(),
+                        "qty": package_item.quantity,
+                        "thumbnail": included_thumb.image.url if included_thumb else None,
+                    }
+                )
 
-        variant_payload = {
-            "id": variant.id,
-            "tier": variant.tier,
-            "title": variant.title,
-            "short_description": variant.short_description,
-            "description": variant.description,
-            "price": float(variant.price),
-            "sale_price": float(variant.sale_price) if variant.sale_price else None,
-            "currency": variant.currency,
-            "in_stock": variant_inventory["in_stock"],
-            "can_purchase": variant_inventory["can_purchase"],
-            "availability_label": variant_inventory["availability_label"],
-            "quantity": variant_inventory["quantity"],
-            "cart_cta_label": variant_inventory["cart_cta_label"],
-            "thumbnail": thumb.image.url if thumb else None,
-            "images": images,
-            "package_items": package_items,
-            "is_default": variant.is_default,
-            "sort_order": variant.sort_order,
-        }
-        variants.append(variant_payload)
+            variant_payload = {
+                "id": variant.id,
+                "tier": variant.tier,
+                "title": variant.title,
+                "short_description": variant.short_description,
+                "description": variant.description,
+                "price": float(variant.price),
+                "sale_price": float(variant.sale_price) if variant.sale_price else None,
+                "currency": variant.currency,
+                "in_stock": variant_inventory["in_stock"],
+                "can_purchase": variant_inventory["can_purchase"],
+                "availability_label": variant_inventory["availability_label"],
+                "quantity": variant_inventory["quantity"],
+                "cart_cta_label": variant_inventory["cart_cta_label"],
+                "thumbnail": thumb.image.url if thumb else None,
+                "images": images,
+                "package_items": package_items,
+                "is_default": variant.is_default,
+                "sort_order": variant.sort_order,
+            }
+            system_variants.append(variant_payload)
 
-        if variant.is_default and not default_variant:
-            default_variant = variant_payload
+            if variant.is_default and not default_system_variant:
+                default_system_variant = variant_payload
 
-    if variants and not default_variant:
-        default_variant = sorted(
-            variants,
-            key=lambda item: (tier_priority.get(item["tier"], 99), item["sort_order"]),
-        )[0]
+        if system_variants and not default_system_variant:
+            default_system_variant = sorted(
+                system_variants,
+                key=lambda item: (tier_priority.get(item["tier"], 99), item["sort_order"]),
+            )[0]
+    else:
+        variants_qs = variants_qs.order_by("sort_order")
+        for variant in variants_qs:
+            variant_inventory = variant.get_inventory_data()
+            variant_images = [
+                {"url": image.image.url, "alt_text": image.alt_text or variant.title}
+                for image in variant.images.all()
+            ]
+            short_lines = [
+                line.strip()
+                for line in (variant.short_description or "").splitlines()
+                if line.strip()
+            ]
+            normal_variant_payload = {
+                "id": variant.id,
+                "title": variant.title,
+                "sku": getattr(variant, "sku", "") if hasattr(variant, "sku") else "",
+                "short_description": variant.short_description,
+                "short_description_lines": short_lines,
+                "description": variant.description,
+                "price": float(variant.price),
+                "sale_price": float(variant.sale_price) if variant.sale_price else None,
+                "currency": variant.currency,
+                "in_stock": variant_inventory["in_stock"],
+                "can_purchase": variant_inventory["can_purchase"],
+                "availability_label": variant_inventory["availability_label"],
+                "quantity": variant_inventory["quantity"],
+                "cart_cta_label": variant_inventory["cart_cta_label"],
+                "images": variant_images,
+                "is_default": variant.is_default,
+                "sort_order": variant.sort_order,
+            }
+            normal_variants.append(normal_variant_payload)
+            if variant.is_default and not default_normal_variant:
+                default_normal_variant = normal_variant_payload
+
+        # Default-selection rule for normal products:
+        # configured default first, otherwise first active ordered variant.
+        if normal_variants and not default_normal_variant:
+            default_normal_variant = normal_variants[0]
 
     return render(
         request,
         "shop/single_product.html",
         {
             "product": product,
-            "variants": variants,
-            "default_variant": default_variant,
+            "variants": system_variants,
+            "default_variant": default_system_variant,
+            "normal_variants": normal_variants,
+            "default_normal_variant": default_normal_variant,
             # Always canonicalize product detail pages to the slug-based product URL.
             "canonical_url": request.build_absolute_uri(parent_product.get_absolute_url()),
             "product_json_ld": _json_for_script_tag(
@@ -248,7 +292,7 @@ def single_product(request, locat=None, slug=None):
                     request=request,
                     product_data=product,
                     parent_product=parent_product,
-                    default_variant=default_variant if product.get("system") else None,
+                    default_variant=default_system_variant if product.get("system") else None,
                 )
             ),
         },

--- a/static/doobarashop/js/features/cartActions.js
+++ b/static/doobarashop/js/features/cartActions.js
@@ -78,18 +78,24 @@ function bindAddToCartButtons() {
   }
 
   addToCartButtons.forEach((button) => {
-    if (button.dataset.variantId) {
+    // System bundle variants are handled by their dedicated controller to avoid duplicate requests.
+    if (button.dataset.cartHandler === 'system') {
       return;
     }
 
     button.addEventListener('click', async () => {
       const quantityField = document.getElementById('spq');
       const quantity = quantityField ? quantityField.value : 1;
-
-      const response = await sendJson('/shopaddtocart', 'PUT', {
-        pid: button.value,
+      const payload = {
         quantity,
-      });
+      };
+      if (button.dataset.variantId) {
+        payload.variant_id = button.dataset.variantId;
+      } else {
+        payload.pid = button.value;
+      }
+
+      const response = await sendJson('/shopaddtocart', 'PUT', payload);
 
       const result = await response.json();
 

--- a/static/doobarashop/js/features/productVariants.js
+++ b/static/doobarashop/js/features/productVariants.js
@@ -2,22 +2,129 @@ export function initProductVariants() {
   const variantSelector = document.getElementById('variants');
   const addToCartButton = document.getElementById('spatc');
   const productPrice = document.getElementById('spp');
+  const availability = document.getElementById('normal-variant-availability');
+  const comparePrice = document.getElementById('normal-variant-compare-price');
+  const mainImage = document.getElementById('spi');
+  const gallery = document.getElementById('normal-variant-gallery');
+  const shortSpecs = document.getElementById('normal-variant-short-specs');
+  const longDescription = document.getElementById('longdescription');
+  const variantDataElement = document.getElementById('normal-variant-data');
 
-  if (!variantSelector || !addToCartButton || !productPrice) {
+  if (!variantSelector || !addToCartButton || !productPrice || !variantDataElement) {
     return;
   }
 
-  variantSelector.addEventListener('change', () => {
-    const selectedValue = variantSelector.options[variantSelector.selectedIndex]?.value;
+  let variants = [];
+  try {
+    variants = JSON.parse(variantDataElement.textContent || '[]');
+  } catch (error) {
+    return;
+  }
 
-    if (!selectedValue) {
+  if (!Array.isArray(variants) || !variants.length) {
+    return;
+  }
+
+  const baseGalleryMarkup = gallery ? gallery.innerHTML : '';
+  const baseShortSpecsMarkup = shortSpecs ? shortSpecs.innerHTML : '';
+  const baseLongDescriptionMarkup = longDescription ? longDescription.innerHTML : '';
+  const baseMainImage = mainImage ? { src: mainImage.getAttribute('src') || '', alt: mainImage.getAttribute('alt') || '' } : null;
+
+  function renderVariant(variant) {
+    if (!variant) {
       return;
     }
 
-    const normalized = selectedValue.replaceAll("'", '"');
-    const variant = JSON.parse(normalized);
+    // Keep cart payload explicit so backend adds the selected variant, not the parent product.
+    addToCartButton.dataset.variantId = String(variant.id);
+    addToCartButton.dataset.gaItemId = String(variant.id);
+    addToCartButton.dataset.gaItemName = variant.title || '';
+    addToCartButton.dataset.gaPrice = String(variant.sale_price ?? variant.price ?? 0);
+    addToCartButton.dataset.gaCurrency = variant.currency || addToCartButton.dataset.gaCurrency || 'USD';
+    addToCartButton.disabled = !variant.can_purchase;
+    addToCartButton.textContent = variant.cart_cta_label || 'Out of Stock';
 
-    addToCartButton.value = variant.id;
-    productPrice.innerHTML = Number(variant.price).toFixed(2);
+    const activePrice = variant.sale_price ?? variant.price;
+    productPrice.textContent = `$ ${Number(activePrice || 0).toFixed(2)}`;
+
+    if (comparePrice) {
+      if (variant.sale_price) {
+        comparePrice.classList.remove('is-hidden');
+        comparePrice.innerHTML = `<span>$ ${Number(variant.price || 0).toFixed(2)}</span>`;
+      } else {
+        comparePrice.classList.add('is-hidden');
+        comparePrice.innerHTML = '';
+      }
+    }
+
+    if (availability) {
+      availability.textContent = variant.availability_label || 'Out of Stock';
+      availability.classList.toggle('is-in-stock', Boolean(variant.can_purchase));
+      availability.classList.toggle('is-out-of-stock', !variant.can_purchase);
+    }
+
+    if (gallery && mainImage) {
+      const images = Array.isArray(variant.images) ? variant.images : [];
+      if (!images.length) {
+        // Variant fallback: keep parent product gallery/images when a variant has no dedicated media.
+        gallery.innerHTML = baseGalleryMarkup;
+        if (baseMainImage) {
+          mainImage.src = baseMainImage.src;
+          mainImage.alt = baseMainImage.alt;
+        }
+      } else {
+        gallery.innerHTML = '';
+        images.forEach((image, index) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'single-product-thumb';
+          const img = document.createElement('img');
+          img.className = 'sp-thumb-image';
+          img.src = image.url;
+          img.alt = image.alt_text || variant.title || '';
+          button.appendChild(img);
+          button.addEventListener('click', () => {
+            mainImage.src = image.url;
+            mainImage.alt = image.alt_text || variant.title || '';
+          });
+          if (index === 0) {
+            mainImage.src = image.url;
+            mainImage.alt = image.alt_text || variant.title || '';
+          }
+          gallery.appendChild(button);
+        });
+      }
+    }
+
+    if (shortSpecs) {
+      const lines = Array.isArray(variant.short_description_lines) ? variant.short_description_lines : [];
+      // Only override specs content when variant actually carries its own content.
+      if (lines.length) {
+        shortSpecs.innerHTML = '';
+        lines.forEach((line) => {
+          const listItem = document.createElement('li');
+          listItem.textContent = line;
+          shortSpecs.appendChild(listItem);
+        });
+      } else {
+        shortSpecs.innerHTML = baseShortSpecsMarkup;
+      }
+    }
+
+    if (longDescription) {
+      // Only override long description when variant has override content.
+      longDescription.innerHTML = variant.description ? variant.description : baseLongDescriptionMarkup;
+    }
+  }
+
+  const defaultVariantIdElement = document.getElementById('default-normal-variant-id');
+  const defaultVariantId = defaultVariantIdElement ? Number(JSON.parse(defaultVariantIdElement.textContent || '0')) : 0;
+  const defaultVariant = variants.find((variant) => variant.id === defaultVariantId) || variants[0];
+  renderVariant(defaultVariant);
+
+  variantSelector.addEventListener('change', () => {
+    const variantId = Number(variantSelector.value);
+    const variant = variants.find((item) => item.id === variantId);
+    renderVariant(variant);
   });
 }


### PR DESCRIPTION
### Motivation
- Add support for switching between NORMAL product variants on the single product page while making minimal, localized changes and preserving the existing system (bundle/tier) product flow.
- I inspected the product detail serialization and templates (`shop/modeling/serialize_helper.py`, `shop/templates/shop/single_product.html`), the single-product view (`shop/views.py`), cart manager (`cart/modules/cartmanager.py`), cart model (`cart/models.py`), and frontend controllers (`static/doobarashop/js/features/*.js`) to choose the smallest safe path.
- The change must not alter system product/tier logic, not refactor global styles, and must keep canonical parent product URLs unchanged.

### Description
- Backend: extended `shop.views.single_product` to produce a separate `normal_variants` payload and `default_normal_variant` while leaving the existing system variant (`variants` / `default_variant`) logic untouched so bundle flows remain identical (`shop/views.py`).
- Template: updated `shop/templates/shop/single_product.html` to render a normal-product selector only when `normal_variants` exist, to initialize price/availability/specs/description from the default normal variant, and to expose a JSON script payload for client-side switching; system-product markup is unchanged and canonical behavior preserved.
- Frontend: implemented a small controller in `static/doobarashop/js/features/productVariants.js` that parses the `normal-variant-data` JSON and swaps price, compare-price, availability, main image + gallery (with fallback to parent product images), short specs and long description only when the variant provides overrides, and ensures the add-to-cart button metadata carries `data-variant-id` so the backend receives the selected variant.
- Cart wiring and naming: updated `static/doobarashop/js/features/cartActions.js` to include `variant_id` in the `/shopaddtocart` payload when present (system variant buttons are explicitly skipped by the general binder to avoid duplicate handling), and updated `cart/models.py` to produce clearer cart line labels showing parent product + chosen variant.
- Styling: added scoped compare-price rules only to `shop/sass/pages/_single-product.scss` (no global CSS changes). All meaningful changes include concise code comments explaining intent and fallbacks.

### Testing
- `python -m py_compile shop/views.py cart/models.py` ran successfully to validate Python syntax.
- `python manage.py check` could not be completed in this environment because `SECRET_KEY` is not set, so full Django system checks were not executed (this is an environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5401153d4832493171c85b58a2133)