### PR TITLE
Render system variant descriptions with same formatting as normal products

### DIFF
--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -40,7 +40,12 @@
                         <div class="single-product-price-wrap">
                             <span class="single-product-price-label">Selected Variant</span>
                             <h2 id="system-variant-title" class="single-product-price">{{ default_system_variant.title }}</h2>
-                            <p id="system-variant-short-description">{{ default_system_variant.short_description }}</p>
+                            {# NEW: Render pre-split system variant short description as bullet list items. #}
+                            <ul id="system-variant-short-description" class="single-product-spec-list">
+                                {% for line in default_system_variant.short_description_lines %}
+                                    <li>{{ line }}</li>
+                                {% endfor %}
+                            </ul>
                             <p id="system-variant-availability" class="single-product-availability {% if default_system_variant.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}">
                                 {{ default_system_variant.availability_label }}
                             </p>
@@ -213,7 +218,12 @@
                     <h2>Description</h2>
                 </div>
                 <div class="single-product-richtext" id="longdescription">
-                    {{ product.plongdescription|safe }}
+                    {# NEW: Keep initial system variant long description consistent with switched state. #}
+                    {% if product.system and default_system_variant %}
+                        {{ default_system_variant.long_description_html|safe }}
+                    {% else %}
+                        {{ product.plongdescription|safe }}
+                    {% endif %}
                 </div>
             </div>
 

--- a/shop/views.py
+++ b/shop/views.py
@@ -1,4 +1,5 @@
 import json
+import markdown
 
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -191,6 +192,13 @@ def single_product(request, locat=None, slug=None):
 
     for variant in system_variants_qs:
         variant_inventory = variant.get_inventory_data()
+        # NEW: Pre-split multiline short description into bullet-ready lines
+        # so system variants match normal product formatting behavior.
+        short_description_lines = [
+            line.strip() for line in (variant.short_description or "").splitlines() if line.strip()
+        ]
+        # NEW: Convert markdown/plain long description to HTML server-side.
+        long_description_html = markdown.markdown(variant.description or "")
         thumb = variant.images.filter(thumbnail=True).first() or variant.images.first()
         images = [
             {"url": image.image.url, "alt_text": image.alt_text}
@@ -214,6 +222,9 @@ def single_product(request, locat=None, slug=None):
             "title": variant.title,
             "short_description": variant.short_description,
             "description": variant.description,
+            # NEW: Ready-to-render description payload for system tier switching.
+            "short_description_lines": short_description_lines,
+            "long_description_html": long_description_html,
             "price": float(variant.price),
             "sale_price": float(variant.sale_price) if variant.sale_price else None,
             "currency": variant.currency,

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -79,9 +79,18 @@ function renderVariant(variant) {
   const addToCartButton = document.getElementById('spatc');
   const specifications = document.getElementById('longdescription');
 
-  if (specifications) specifications.textContent = variant.description || '';
+  // NEW: System variant long description is pre-rendered HTML from server-side markdown conversion.
+  if (specifications) specifications.innerHTML = variant.long_description_html || '';
   if (title) title.textContent = variant.title || '';
-  if (shortDescription) shortDescription.textContent = variant.short_description || '';
+  // NEW: Rebuild bullet list from pre-split short description lines.
+  if (shortDescription) {
+    shortDescription.innerHTML = '';
+    (variant.short_description_lines || []).forEach((line) => {
+      const listItem = document.createElement('li');
+      listItem.textContent = line;
+      shortDescription.appendChild(listItem);
+    });
+  }
   if (price) {
     const activePrice = variant.sale_price ?? variant.price;
     price.textContent = `$ ${Number(activePrice).toFixed(2)}`;


### PR DESCRIPTION
### Motivation
- System-tier switches on the single-product page displayed raw short and long description text while normal products used server-side preprocessing to produce safe HTML and line lists.
- The goal is to make system variants use the same server-side formatting rules so initial render and JS-driven tier switching are consistent and safe.

### Description
- Preprocess each system variant in `single_product` view by splitting `short_description` into `short_description_lines` and converting `description` to `long_description_html` using server-side `markdown` so the payload is render-ready. (`shop/views.py`)
- Include the prepared fields `short_description_lines` and `long_description_html` in the variant JSON payload so client code and templates consume safe, formatted data. (`shop/views.py`)
- Update the single-product template to render the system-variant short description as a `<ul>` from `short_description_lines` and to use `default_system_variant.long_description_html` for the description block when the product is a system. (`shop/templates/shop/single_product.html`)
- Update the tier-switching JS to rebuild the short-description list from `short_description_lines` and inject `long_description_html` into the description area (using `innerHTML`), preserving existing add-to-cart and selection logic. (`static/doobarashop/js/features/systemVariants.js`)
- New code is commented to explain the added preprocessing and why the prepared fields are used (no client-side markdown conversion).

### Testing
- Ran `python -m compileall shop/views.py static/doobarashop/js/features/systemVariants.js` which succeeded (Python sources compile cleanly).
- Ran `python manage.py check` in this environment which failed due to missing runtime configuration (`SECRET_KEY is not set`), so full Django checks could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a7b12a6883248a9f3445f0d0ed7f)