### PR TITLE
Add automatic Google/Meta CSV catalog feed endpoints

### DIFF
--- a/shop/modeling/feed_export.py
+++ b/shop/modeling/feed_export.py
@@ -1,4 +1,9 @@
+import csv
+import re
 from decimal import Decimal, InvalidOperation
+
+from django.http import HttpResponse
+from django.utils.html import strip_tags
 
 from ..models import Product
 
@@ -25,6 +30,22 @@ _CATEGORY_MAPPING_RULES = [
     },
 ]
 
+# NEW: First-pass CSV columns requested for Google Merchant and Meta catalogs.
+# Keep one shared ordered list so both endpoints stay consistent and easy to maintain.
+_CSV_FIELDS = [
+    "id",
+    "title",
+    "description",
+    "availability",
+    "condition",
+    "price",
+    "link",
+    "image_link",
+    "brand",
+    "product_type",
+    "additional_image_link",
+]
+
 
 def _primary_image(product):
     """
@@ -32,6 +53,12 @@ def _primary_image(product):
     This stays internal so storefront serializers are not affected.
     """
     return product.images.filter(thumbnail=True).first() or product.images.first()
+
+
+# NEW: System-tier variants have their own image relation, so we mirror existing
+# "thumbnail first, then first image" behavior used across the project.
+def _primary_system_variant_image(variant):
+    return variant.images.filter(thumbnail=True).first() or variant.images.first()
 
 
 def _absolute_product_url(request, product):
@@ -50,6 +77,18 @@ def _absolute_image_url(request, product):
     if not image:
         return None
     return request.build_absolute_uri(image.image.url)
+
+
+# NEW: Build optional "additional_image_link" from non-primary product images.
+# Merchant feeds accept a comma-separated list in a single column for CSV exports.
+def _additional_product_image_urls(request, product):
+    primary = _primary_image(product)
+    urls = []
+    for image in product.images.all():
+        if primary and image.id == primary.id:
+            continue
+        urls.append(request.build_absolute_uri(image.image.url))
+    return ", ".join(urls) if urls else None
 
 
 def _normalized_availability(product):
@@ -79,6 +118,14 @@ def _normalized_price(value):
         return f"{Decimal(value):.2f}"
     except (InvalidOperation, TypeError, ValueError):
         return None
+
+
+# NEW: Channel feeds require a clean plain-text description. We strip any HTML
+# and collapse whitespace so both Google and Meta ingest stable text.
+def _plain_text_description(value):
+    text = strip_tags(value or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
 
 
 def _category_names(product):
@@ -155,7 +202,112 @@ def product_feed_queryset():
     Queryset used by feed export endpoint.
     Limited to active products to match publicly listed catalog behavior.
     """
-    return Product.objects.filter(active=True).prefetch_related("images")
+    return Product.objects.filter(active=True).prefetch_related(
+        "images",
+        "category",
+        "normal_variants",
+        "variants__images",
+    )
+
+
+# NEW: Shared purchasable-offer expansion.
+# We emit one row per actual selectable option when variants/tiers exist, and one
+# row for simple products. This avoids ambiguous parent-level rows.
+def _iter_feed_offers(request):
+    for product in product_feed_queryset():
+        base_description = _plain_text_description(
+            product.short_description or product.description
+        )
+        base_product_type = _product_type_from_categories(product)
+        base_brand = (product.brand or "").strip() or None
+        base_link = _absolute_product_url(request, product)
+        base_condition = "new"
+        base_availability = _normalized_availability(product)
+
+        # System products: one row for each active tier/variant.
+        if product.is_system:
+            for variant in product.variants.filter(active=True).order_by("sort_order", "id"):
+                inventory = variant.get_inventory_data()
+                variant_image = _primary_system_variant_image(variant)
+                image_url = (
+                    request.build_absolute_uri(variant_image.image.url)
+                    if variant_image
+                    else _absolute_image_url(request, product)
+                )
+                offer_description = _plain_text_description(
+                    variant.short_description or variant.description or base_description
+                )
+                yield {
+                    "id": f"{product.id}-system-{variant.id}",
+                    "title": f"{product.name} - {variant.title}",
+                    "description": offer_description,
+                    "availability": "in stock" if inventory["in_stock"] else "out of stock",
+                    "condition": base_condition,
+                    "price": _normalized_price(variant.sale_price or variant.price),
+                    "link": base_link,
+                    "image_link": image_url,
+                    "brand": base_brand,
+                    "product_type": base_product_type,
+                    "additional_image_link": _additional_product_image_urls(request, product),
+                }
+            continue
+
+        # Non-system products with selectable normal variants: one row per variant.
+        active_normal_variants = [
+            variant for variant in product.normal_variants.all() if variant.active
+        ]
+        if active_normal_variants:
+            for variant in sorted(active_normal_variants, key=lambda item: (item.sort_order, item.id)):
+                image_url = (
+                    request.build_absolute_uri(variant.image.url)
+                    if variant.image
+                    else _absolute_image_url(request, product)
+                )
+                offer_description = _plain_text_description(
+                    variant.short_description or base_description
+                )
+                yield {
+                    "id": f"{product.id}-variant-{variant.id}",
+                    "title": f"{product.name} - {variant.title}",
+                    "description": offer_description,
+                    "availability": base_availability,
+                    "condition": base_condition,
+                    "price": _normalized_price(variant.sale_price or variant.price),
+                    "link": base_link,
+                    "image_link": image_url,
+                    "brand": base_brand,
+                    "product_type": base_product_type,
+                    "additional_image_link": _additional_product_image_urls(request, product),
+                }
+            continue
+
+        # Simple products: one row using existing product-level purchasable fields.
+        yield {
+            "id": str(product.id),
+            "title": product.name,
+            "description": base_description,
+            "availability": base_availability,
+            "condition": base_condition,
+            "price": _normalized_price(product.sale_price or product.price),
+            "link": base_link,
+            "image_link": _absolute_image_url(request, product),
+            "brand": base_brand,
+            "product_type": base_product_type,
+            "additional_image_link": _additional_product_image_urls(request, product),
+        }
+
+
+# NEW: Shared CSV response builder for scheduled catalog fetches.
+def build_catalog_csv_response(request, *, filename):
+    response = HttpResponse(content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = f'inline; filename="{filename}"'
+
+    writer = csv.DictWriter(response, fieldnames=_CSV_FIELDS, extrasaction="ignore")
+    writer.writeheader()
+    for row in _iter_feed_offers(request):
+        writer.writerow(row)
+
+    return response
 
 
 def build_product_feed_payload(request):

--- a/shop/urls.py
+++ b/shop/urls.py
@@ -23,4 +23,8 @@ urlpatterns=[
     path("orderby", views.orderby, name="orderby"),
     # Internal product feed export (JSON) for Merchant/Meta mapping QA.
     path("internal/exports/products.json", views.internal_product_feed_export, name="internal_product_feed_export"),
+    # NEW: Live Google Merchant Center CSV feed endpoint.
+    path("google-product-feed.csv", views.google_product_feed_csv, name="google_product_feed_csv"),
+    # NEW: Live Meta Commerce Manager CSV feed endpoint.
+    path("meta-catalog-feed.csv", views.meta_catalog_feed_csv, name="meta_catalog_feed_csv"),
 ]

--- a/shop/views.py
+++ b/shop/views.py
@@ -11,7 +11,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 # Created modules to manage shop page functions
 from .modeling.serialize_helper import *
 from .modeling.filter_helper import *
-from .modeling.feed_export import build_product_feed_payload
+from .modeling.feed_export import build_catalog_csv_response, build_product_feed_payload
 
 _JSON_SCRIPT_ESCAPES = {
     ord(">"): "\\u003E",
@@ -337,6 +337,22 @@ def internal_product_feed_export(request):
     """
     payload = build_product_feed_payload(request)
     return JsonResponse(payload)
+
+
+def google_product_feed_csv(request):
+    """
+    NEW: Public CSV endpoint for Google Merchant Center scheduled fetches.
+    Keeps feed generation centralized in modeling.feed_export.
+    """
+    return build_catalog_csv_response(request, filename="google-product-feed.csv")
+
+
+def meta_catalog_feed_csv(request):
+    """
+    NEW: Public CSV endpoint for Meta Commerce Manager scheduled fetches.
+    Uses the same normalized offer rows to avoid logic drift.
+    """
+    return build_catalog_csv_response(request, filename="meta-catalog-feed.csv")
 
 
 # request -> render(url)


### PR DESCRIPTION
### Motivation
- Provide live CSV feed endpoints so Google Merchant Center and Meta Commerce Manager can fetch catalog data automatically without manual uploads.
- Ensure feed rows represent real purchasable offers (one row per actual selectable variant/tier or simple product) and reuse existing pricing/inventory logic.
- Keep changes minimal and maintainable by reusing existing models/serializers and centralizing CSV generation.

### Description
- Added two public endpoints `google-product-feed.csv` and `meta-catalog-feed.csv` and wired them in `shop/urls.py` to `google_product_feed_csv` and `meta_catalog_feed_csv` in `shop/views.py`.
- Implemented shared CSV export logic in `shop/modeling/feed_export.py`, including `_CSV_FIELDS`, `build_catalog_csv_response(request, *, filename)`, and `_iter_feed_offers(request)` which expands products into one row per purchasable offer (system `variants`, `normal_variants`, or simple product).
- Reused model rules such as `get_inventory_data` and sale-vs-base pricing; added helpers `_primary_system_variant_image`, `_additional_product_image_urls`, `_plain_text_description`, and updated `product_feed_queryset()` prefetches to avoid extra queries.
- CSV response uses real `text/csv` content type with an inline filename and includes `additional_image_link` (comma-separated non-primary images); all new code is commented to explain behavior and intent.

### Testing
- `python manage.py check` initially failed in this environment due to `SECRET_KEY` missing (environment issue), as expected in an isolated CI-like runner.
- `SECRET_KEY=dummy python manage.py check` ran and reported system checks passed (succeeded).
- A lightweight exercise using `python manage.py shell` + `RequestFactory` to invoke the feed views was attempted but failed due to no local database connection (`psycopg2.OperationalError`) in the test environment; this is an environment-level issue and not a code error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94268f510832490d3324b22b867b0)