### PR TITLE
Add Open Graph & Twitter/X social metadata with product-level overrides

### DIFF
--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -3,6 +3,15 @@
 
 {% block title %}{{ product.title }} | Doobara{% endblock %}
 {% block meta_description %}{% if product.pshortdescription and product.pshortdescription.0 %}{{ product.pshortdescription.0|striptags|truncatechars:155 }}{% else %}Buy {{ product.title }} from Doobara with practical smart-home-focused support and fast local delivery options.{% endif %}{% endblock %}
+{# NEW: Product pages override social metadata blocks so previews use real product data. #}
+{% block og_type %}product{% endblock %}
+{% block og_title %}{{ social_title|default:product.title }}{% endblock %}
+{% block og_description %}{{ social_description|default:product.title }}{% endblock %}
+{% block og_url %}{{ social_url|default:canonical_url }}{% endblock %}
+{% block og_image %}{% if social_image %}{{ social_image }}{% else %}{{ request.scheme }}://{{ request.get_host }}{% static 'doobarashop/upload/images/logo-creation.png' %}{% endif %}{% endblock %}
+{% block twitter_title %}{{ social_title|default:product.title }}{% endblock %}
+{% block twitter_description %}{{ social_description|default:product.title }}{% endblock %}
+{% block twitter_image %}{% if social_image %}{{ social_image }}{% else %}{{ request.scheme }}://{{ request.get_host }}{% static 'doobarashop/upload/images/logo-creation.png' %}{% endif %}{% endblock %}
 
 {% block body %}
 <section class="single-product-page">

--- a/shop/views.py
+++ b/shop/views.py
@@ -274,6 +274,21 @@ def single_product(request, locat=None, slug=None):
     if normal_variants and not default_normal_variant:
         default_normal_variant = normal_variants[0]
 
+    # NEW: Build social preview metadata once in view so templates stay clean and block-driven.
+    social_title = (product.get("title") or "").strip()
+    social_description = (
+        ((product.get("pshortdescription") or [None])[0] or "").strip()
+        or (f"Buy {social_title} from Doobara with practical smart-home-focused support and fast local delivery options." if social_title else "")
+    )
+    social_url = request.build_absolute_uri(parent_product.get_absolute_url())
+
+    # NEW: Social cards require absolute image URLs; prefer variant thumbnail for systems then product image.
+    social_image = None
+    if product.get("system") and default_system_variant and default_system_variant.get("thumbnail"):
+        social_image = request.build_absolute_uri(default_system_variant["thumbnail"])
+    elif product.get("main_image", {}).get("url"):
+        social_image = request.build_absolute_uri(product["main_image"]["url"])
+
     return render(
         request,
         "shop/single_product.html",
@@ -284,7 +299,12 @@ def single_product(request, locat=None, slug=None):
             "normal_variants": normal_variants,
             "default_normal_variant": default_normal_variant,
             # Always canonicalize product detail pages to the slug-based product URL.
-            "canonical_url": request.build_absolute_uri(parent_product.get_absolute_url()),
+            "canonical_url": social_url,
+            # NEW: Product detail template uses these for Open Graph and Twitter/X blocks.
+            "social_title": social_title,
+            "social_description": social_description,
+            "social_image": social_image,
+            "social_url": social_url,
             "product_json_ld": _json_for_script_tag(
                 # JSON string consumed directly by <script type="application/ld+json">.
                 _build_product_json_ld(

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -6,6 +6,22 @@
     <title>{% block title %}Doobara | Smart Home Products & Automation{% endblock %}</title>
     <meta name="description" content="{% block meta_description %}Discover Doobara smart home products, practical automation systems, and reliable support for modern living in Lebanon.{% endblock %}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {# NEW: Canonical URL remains overrideable via view context for SEO and sharing consistency. #}
+    {% if canonical_url %}
+    <link rel="canonical" href="{{ canonical_url }}">
+    {% endif %}
+    {# NEW: Open Graph defaults with dedicated blocks so child templates can override per page. #}
+    <meta property="og:title" content="{% block og_title %}{% block social_title %}Doobara | Smart Home Products & Automation{% endblock %}{% endblock %}">
+    <meta property="og:type" content="{% block og_type %}website{% endblock %}">
+    <meta property="og:url" content="{% block og_url %}{% if canonical_url %}{{ canonical_url }}{% else %}{{ request.build_absolute_uri }}{% endif %}{% endblock %}">
+    <meta property="og:image" content="{% block og_image %}{{ request.scheme }}://{{ request.get_host }}{% static 'doobarashop/upload/images/logo-creation.png' %}{% endblock %}">
+    <meta property="og:description" content="{% block og_description %}{% block social_description %}Discover Doobara smart home products, practical automation systems, and reliable support for modern living in Lebanon.{% endblock %}{% endblock %}">
+    <meta property="og:site_name" content="{% block og_site_name %}Doobara{% endblock %}">
+    {# NEW: Twitter/X card tags mirror social defaults for consistent previews across platforms. #}
+    <meta name="twitter:card" content="{% block twitter_card %}summary_large_image{% endblock %}">
+    <meta name="twitter:title" content="{% block twitter_title %}{% block social_title_twitter %}Doobara | Smart Home Products & Automation{% endblock %}{% endblock %}">
+    <meta name="twitter:description" content="{% block twitter_description %}{% block social_description_twitter %}Discover Doobara smart home products, practical automation systems, and reliable support for modern living in Lebanon.{% endblock %}{% endblock %}">
+    <meta name="twitter:image" content="{% block twitter_image %}{{ request.scheme }}://{{ request.get_host }}{% static 'doobarashop/upload/images/logo-creation.png' %}{% endblock %}">
     {% if GOOGLE_SITE_VERIFICATION %}
     <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">
     {% endif %}
@@ -17,9 +33,6 @@
       gtag('js', new Date());
       gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
     </script>
-    {% endif %}
-    {% if canonical_url %}
-    <link rel="canonical" href="{{ canonical_url }}">
     {% endif %}
     {% if META_PIXEL_ID %}
     {# Meta Pixel: base code + PageView (global) #}


### PR DESCRIPTION
### Motivation
- Ensure product and page URLs produce correct rich preview cards (image, title, description, canonical URL) when shared on WhatsApp, Facebook, LinkedIn, X, and similar platforms.
- Provide a clean, block-based template structure so child templates can override `title`, `description`, `image`, `og:type`, and canonical/share URL per page.
- Use absolute URLs for images and canonical links so external share preview tools (e.g. Meta Sharing Debugger) can resolve assets reliably.

### Description
- Added Open Graph and Twitter/X tags with sensible defaults and dedicated blocks to the shared base layout head in `templates/doobarashop/layout.html` so child templates can override values (`og:title`, `og:type`, `og:url`, `og:image`, `og:description`, `og:site_name`, `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`).
- Kept existing canonical support and wired `og:url` to use the provided `canonical_url` when present, otherwise `request.build_absolute_uri` (absolute current URL).
- Updated the product detail template `shop/templates/shop/single_product.html` to override the social metadata blocks and set `og:type` to `product`, falling back to a site logo absolute URL when product image data is not available.
- Updated `shop/views.py` to compute and inject `social_title`, `social_description`, `social_image`, and `social_url` into the product detail context, preferring system variant thumbnail then main product image and using `request.build_absolute_uri` to ensure absolute image URLs; all new template code is commented to explain behavior.

### Testing
- Ran `python manage.py check` in this environment and it failed due to environment configuration (`SECRET_KEY is not set`) so full Django checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c946c6f3b88324b05fd4a6a37598df)