### PR TITLE
Add safe native lazy-loading and intrinsic sizes to storefront templates

### DIFF
--- a/blog/templates/blog/blog.html
+++ b/blog/templates/blog/blog.html
@@ -15,7 +15,7 @@ BLOG
     <a href="single_blog_post">
         <div class="post-card">
             <!-- Post Image -->
-            <img src="{% static 'doobarashop/upload/images/blog1.jpg' %}">
+            <img src="{% static 'doobarashop/upload/images/blog1.jpg' %}" loading="eager">
             <!-- Post title -->
             <h3>Smart Light Switch</h3>
             <!-- Post Meta description -->
@@ -25,7 +25,7 @@ BLOG
 
     <a href="single_blog_post">
         <div class="post-card">
-            <img src="{% static 'doobarashop/upload/images/blog2.jpg' %}">
+            <img src="{% static 'doobarashop/upload/images/blog2.jpg' %}" loading="lazy">
             <h3>Home automation</h3>
             <p>Home automation is not a luxery but it can be too, though its mainly about 
                     making things and routinique task easier and more efficient</p>
@@ -34,7 +34,7 @@ BLOG
 
     <a href="single_blog_post">
         <div class="post-card">
-            <img src="{% static 'doobarashop/upload/images/blog3.jpg' %}">
+            <img src="{% static 'doobarashop/upload/images/blog3.jpg' %}" loading="lazy">
             <h3>Smart Home devices</h3>
             <p>To convert your house to a smart one you should teach how to do and orginize 
                     things in your daily life, like coffee, blind, Security and more </p>
@@ -43,7 +43,7 @@ BLOG
 
     <a href="single_blog_post">
         <div class="post-card">
-            <img src="{% static 'doobarashop/upload/images/blog4.jpg' %}">
+            <img src="{% static 'doobarashop/upload/images/blog4.jpg' %}" loading="lazy">
             <h3>Smart Relay Switch</h3>
              <p>Remotely using this relay switch turn ON/OFF any connected 220v appliance
                 all you need is internet connectivity and a smart phone to control and automate it

--- a/blog/templates/blog/single_blog_post.html
+++ b/blog/templates/blog/single_blog_post.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="blog-featured-image">
-        <img src="{% static 'doobarashop/upload/images/blog.jpg' %}">
+        <img src="{% static 'doobarashop/upload/images/blog.jpg' %}" loading="eager" fetchpriority="high">
     </div>
 
     <div class="post-body-content">

--- a/shop/templates/shop/index.html
+++ b/shop/templates/shop/index.html
@@ -37,7 +37,14 @@
                 <div class="hero__blob">
                     <div class="hero__stack">
                         <!-- Replace these with your real images -->  
-                        <img class="hero__img hero__img--phone" src="{% static 'doobarashop/upload/images/phone-app-screen.png' %}" alt="Smart device" />
+                        {# Critical hero image (likely LCP): keep eager for fast above-the-fold render. #}
+                        <img class="hero__img hero__img--phone"
+                             src="{% static 'doobarashop/upload/images/phone-app-screen.png' %}"
+                             alt="Smart device"
+                             loading="eager"
+                             fetchpriority="high"
+                             width="1080"
+                             height="1920" />
                     </div>
                 </div>
             </div>
@@ -60,7 +67,8 @@
                                 </div>
                                 <img class="system-card__img"
                                     src="{{card.image}}"
-                                    alt="Power system devices">
+                                    alt="Power system devices"
+                                    loading="lazy">
                                 <div class="system-card__tag">{{card.tag}}</div>
                             </div>
                             <p class="system-card__desc">{{card.description}}</p>
@@ -94,7 +102,8 @@
                         <div class="system-card__media"> 
                             <img class="system-card__img"
                                 src="{{card.image}}"
-                                alt="Power system devices">
+                                alt="Power system devices"
+                                loading="lazy">
                         </div>
                         <h3 class="system-card__desc">{{card.title}}</h3>
                         <p class="system-card__desc">{{card.description}}</p>
@@ -117,7 +126,11 @@
             <div class="product-card">
             <a href="{{ product.url }}">
                 {% if product.main_image %}
-                    <img src="{{ product.main_image.url }}" alt="{{ product.main_image.alt_text }}">
+                    <img src="{{ product.main_image.url }}"
+                         alt="{{ product.main_image.alt_text }}"
+                         loading="lazy"
+                         width="{{ product.main_image.width }}"
+                         height="{{ product.main_image.height }}">
                 {% else %}
                     <span class="product-card__no-image" aria-label="{{ product.title }} image unavailable"></span>
                 {% endif %}

--- a/shop/templates/shop/shop.html
+++ b/shop/templates/shop/shop.html
@@ -62,7 +62,11 @@
 
                         <div class="shop-card__media">
                             {% if row.main_image %}
-                                <img src="{{ row.main_image.url }}" alt="{{ row.main_image.alt_text }}">
+                                <img src="{{ row.main_image.url }}"
+                                     alt="{{ row.main_image.alt_text }}"
+                                     loading="lazy"
+                                     width="{{ row.main_image.width }}"
+                                     height="{{ row.main_image.height }}">
                             {% else %}
                                 <span class="shop-card__no-image" aria-label="{{ row.title }} image unavailable"></span>
                             {% endif %}

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -22,7 +22,9 @@
                     <div class="single-product-gallery__main">
                         <img id="system-variant-main-image"
                              src="{% if default_system_variant.thumbnail %}{{ default_system_variant.thumbnail }}{% elif product.main_image %}{{ product.main_image.url }}{% endif %}"
-                             alt="{{ default_system_variant.title|default:product.title }}">
+                             alt="{{ default_system_variant.title|default:product.title }}"
+                             loading="eager"
+                             fetchpriority="high">
                     </div>
                     <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
                 </div>
@@ -97,7 +99,11 @@
                         {% if product.main_image %}
                             <img id="spi"
                                  src="{{ product.main_image.url }}"
-                                 alt="{{ product.main_image.alt_text }}">
+                                 alt="{{ product.main_image.alt_text }}"
+                                 loading="eager"
+                                 fetchpriority="high"
+                                 width="{{ product.main_image.width }}"
+                                 height="{{ product.main_image.height }}">
                         {% else %}
                             <div class="single-product-gallery__empty" id="spi" aria-label="{{ product.title }} image unavailable"></div>
                         {% endif %}
@@ -108,7 +114,10 @@
                                 <button type="button" class="single-product-thumb">
                                     <img class="sp-thumb-image"
                                          src="{{image.url }}"
-                                         alt="{{ image.alt_text }}">
+                                         alt="{{ image.alt_text }}"
+                                         loading="lazy"
+                                         width="{{ image.width }}"
+                                         height="{{ image.height }}">
                                 </button>
                         {% endfor %}
                     </div>
@@ -216,7 +225,8 @@
                 <div class="single-product-long-image-card">
                     <img class="single-product-image-long"
                          src="{% static image.iurl %}"
-                         alt="{{ product.title }}">
+                         alt="{{ product.title }}"
+                         loading="lazy">
                 </div>
             {% endif %}
         {% endfor %}

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -85,7 +85,11 @@
           <!-- Logo -->
           <div class="nav-logo">
             <a href="/"> 
-              <img src="{% static 'doobarashop/upload/images/logo-creation.png' %}" alt="home automation doobara">
+              <img src="{% static 'doobarashop/upload/images/logo-creation.png' %}"
+                   alt="home automation doobara"
+                   loading="eager"
+                   width="500"
+                   height="133">
             </a>
           </div>
 


### PR DESCRIPTION
### Motivation
- Improve frontend image loading performance by adding native `loading` hints and intrinsic sizes to reduce CLS while preserving above-the-fold render. 
- Keep changes minimal and safe: only template markup edited, no CSS/JS, no image source rewrites, and no business logic or variant changes.

### Description
- Modified templates: `shop/templates/shop/index.html`, `shop/templates/shop/shop.html`, `shop/templates/shop/single_product.html`, `blog/templates/blog/blog.html`, `blog/templates/blog/single_blog_post.html`, and `templates/doobarashop/layout.html` to add `loading` attributes and safe sizing where available. 
- Homepage (`shop/index.html`): marked hero phone image as critical (kept `loading="eager"` and `fetchpriority="high"` and added `width`/`height` from static file) and marked system/category card images and Most Popular product cards as `loading="lazy"` to defer non-critical images. 
- Shop listing (`shop/shop.html`): product card images now include `loading="lazy"` and use `width="{{ row.main_image.width }}"` / `height="{{ row.main_image.height }}"` when available to avoid layout shift. 
- Single product (`shop/single_product.html`): system/main product images kept eager (LCP candidates) with `fetchpriority="high"` and main image dimensions added where available; gallery thumbnails and long content images set to `loading="lazy"` with intrinsic dimensions for thumbnails when the fields exist. 
- Blog templates (`blog/blog.html`, `blog/single_blog_post.html`): kept featured blog post image eager on the post page and used a conservative pattern in the listing where the first card is `loading="eager"` and subsequent list cards are `loading="lazy"`. 
- Global layout (`templates/doobarashop/layout.html`): logo marked `loading="eager"` and given width/height to stabilize header layout. 
- Applied `fetchpriority="high"` only to clearly critical hero/LCP images and did not add any JS lazy-loading libraries. 
- Flags for future work: templates still use generic image fields like `card.image` and `default_system_variant.thumbnail` without `srcset`/resized variants; these should be addressed in a follow-up to serve responsive thumbnails and correct sized variants.

### Testing
- Verified static hero/logo dimensions via a small Python check using `PIL.Image` which succeeded for files present in the repository. 
- Ran `python manage.py check` which failed due to environment configuration (`SECRET_KEY` not set) so full Django system checks could not be executed in this environment. 
- Verified template diffs locally to confirm only markup changes were introduced and no style or business logic was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9691be7708324bda9a3d33ed0d946)