### PR TITLE
Add native lazy/eager loading attributes and explicit dimensions to storefront images

### DIFF
--- a/blog/templates/blog/blog.html
+++ b/blog/templates/blog/blog.html
@@ -16,7 +16,7 @@ BLOG
         <a href="single_blog_post">
             <div class="post-card">
                 <!-- Post Image -->
-                <img src="{% static 'doobarashop/upload/images/blog1.jpg' %}">
+                <img src="{% static 'doobarashop/upload/images/blog1.jpg' %}" alt="Smart Light Switch" loading="lazy">
                 <!-- Post title -->
                 <h3>Smart Light Switch</h3>
                 <!-- Post Meta description -->
@@ -26,7 +26,7 @@ BLOG
 
         <a href="single_blog_post">
             <div class="post-card">
-                <img src="{% static 'doobarashop/upload/images/blog2.jpg' %}">
+                <img src="{% static 'doobarashop/upload/images/blog2.jpg' %}" alt="Home automation" loading="lazy">
                 <h3>Home automation</h3>
                 <p>Home automation is not a luxery but it can be too, though its mainly about 
                         making things and routinique task easier and more efficient</p>
@@ -35,7 +35,7 @@ BLOG
 
         <a href="single_blog_post">
             <div class="post-card">
-                <img src="{% static 'doobarashop/upload/images/blog3.jpg' %}">
+                <img src="{% static 'doobarashop/upload/images/blog3.jpg' %}" alt="Smart Home devices" loading="lazy">
                 <h3>Smart Home devices</h3>
                 <p>To convert your house to a smart one you should teach how to do and orginize 
                         things in your daily life, like coffee, blind, Security and more </p>
@@ -44,7 +44,7 @@ BLOG
 
         <a href="single_blog_post">
             <div class="post-card">
-                <img src="{% static 'doobarashop/upload/images/blog4.jpg' %}">
+                <img src="{% static 'doobarashop/upload/images/blog4.jpg' %}" alt="Smart Relay Switch" loading="lazy">
                 <h3>Smart Relay Switch</h3>
                 <p>Remotely using this relay switch turn ON/OFF any connected 220v appliance
                     all you need is internet connectivity and a smart phone to control and automate it

--- a/blog/templates/blog/single_blog_post.html
+++ b/blog/templates/blog/single_blog_post.html
@@ -11,7 +11,7 @@
         </div>
 
         <div class="blog-featured-image">
-            <img src="{% static 'doobarashop/upload/images/blog.jpg' %}">
+            <img src="{% static 'doobarashop/upload/images/blog.jpg' %}" alt="Home automation blog cover" loading="eager">
         </div>
 
         <div class="post-body-content">

--- a/shop/templates/shop/index.html
+++ b/shop/templates/shop/index.html
@@ -39,7 +39,13 @@
                     <div class="hero__blob">
                         <div class="hero__stack">
                             <!-- Replace these with your real images -->  
-                            <img class="hero__img hero__img--phone" src="{% static 'doobarashop/upload/images/phone-app-screen.png' %}" alt="Smart device" />
+                            <img class="hero__img hero__img--phone"
+                                 src="{% static 'doobarashop/upload/images/phone-app-screen.png' %}"
+                                 alt="Smart device"
+                                 width="1080"
+                                 height="1920"
+                                 loading="eager"
+                                 fetchpriority="high" />
                         </div>
                     </div>
                 </div>
@@ -63,7 +69,8 @@
                                 </div>
                                 <img class="system-card__img"
                                     src="{{card.image}}"
-                                    alt="Power system devices">
+                                    alt="Power system devices"
+                                    loading="lazy">
                                 <div class="system-card__tag">{{card.tag}}</div>
                             </div>
                             <p class="system-card__desc">{{card.description}}</p>
@@ -97,7 +104,8 @@
                         <div class="system-card__media"> 
                             <img class="system-card__img"
                                 src="{{card.image}}"
-                                alt="Power system devices">
+                                alt="Power system devices"
+                                loading="lazy">
                         </div>
                         <h3 class="system-card__desc">{{card.title}}</h3>
                         <p class="system-card__desc">{{card.description}}</p>
@@ -120,7 +128,11 @@
             <div class="product-card">
             <a href="{{ product.url }}">
                 {% if product.main_image %}
-                    <img src="{{ product.main_image.url }}" alt="{{ product.main_image.alt_text }}">
+                    <img src="{{ product.main_image.url }}"
+                         alt="{{ product.main_image.alt_text }}"
+                         width="400"
+                         height="400"
+                         loading="lazy">
                 {% else %}
                     <span class="product-card__no-image" aria-label="{{ product.title }} image unavailable"></span>
                 {% endif %}
@@ -254,7 +266,11 @@
             <div class="product-card">
             <a href="{{ product.url }}">
                 {% if product.main_image %}
-                    <img src="{{ product.main_image.url }}" alt="{{ product.main_image.alt_text }}">
+                    <img src="{{ product.main_image.url }}"
+                         alt="{{ product.main_image.alt_text }}"
+                         width="400"
+                         height="400"
+                         loading="lazy">
                 {% else %}
                     <span class="product-card__no-image" aria-label="{{ product.title }} image unavailable"></span>
                 {% endif %}
@@ -275,7 +291,11 @@
             <div class="product-card">
             <a href="{{ product.url }}">
                 {% if product.main_image %}
-                    <img src="{{ product.main_image.url }}" alt="{{ product.main_image.alt_text }}">
+                    <img src="{{ product.main_image.url }}"
+                         alt="{{ product.main_image.alt_text }}"
+                         width="400"
+                         height="400"
+                         loading="lazy">
                 {% else %}
                     <span class="product-card__no-image" aria-label="{{ product.title }} image unavailable"></span>
                 {% endif %}

--- a/shop/templates/shop/shop.html
+++ b/shop/templates/shop/shop.html
@@ -62,7 +62,11 @@
 
                         <div class="shop-card__media">
                             {% if row.main_image %}
-                                <img src="{{ row.main_image.url }}" alt="{{ row.main_image.alt_text }}">
+                                <img src="{{ row.main_image.url }}"
+                                     alt="{{ row.main_image.alt_text }}"
+                                     width="600"
+                                     height="600"
+                                     loading="lazy">
                             {% else %}
                                 <span class="shop-card__no-image" aria-label="{{ row.title }} image unavailable"></span>
                             {% endif %}

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -22,7 +22,11 @@
                     <div class="single-product-gallery__main">
                         <img id="system-variant-main-image"
                              src="{% if default_system_variant.thumbnail %}{{ default_system_variant.thumbnail }}{% elif product.main_image %}{{ product.main_image.url }}{% endif %}"
-                             alt="{{ default_system_variant.title|default:product.title }}">
+                             alt="{{ default_system_variant.title|default:product.title }}"
+                             width="1000"
+                             height="1000"
+                             loading="eager"
+                             fetchpriority="high">
                     </div>
                     <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
                 </div>
@@ -97,7 +101,11 @@
                         {% if product.main_image %}
                             <img id="spi"
                                  src="{{ product.main_image.url }}"
-                                 alt="{{ product.main_image.alt_text }}">
+                                 alt="{{ product.main_image.alt_text }}"
+                                 width="1000"
+                                 height="1000"
+                                 loading="eager"
+                                 fetchpriority="high">
                         {% else %}
                             <div class="single-product-gallery__empty" id="spi" aria-label="{{ product.title }} image unavailable"></div>
                         {% endif %}
@@ -108,7 +116,10 @@
                                 <button type="button" class="single-product-thumb">
                                     <img class="sp-thumb-image"
                                          src="{{image.url }}"
-                                         alt="{{ image.alt_text }}">
+                                         alt="{{ image.alt_text }}"
+                                         width="78"
+                                         height="78"
+                                         loading="lazy">
                                 </button>
                         {% endfor %}
                     </div>
@@ -216,7 +227,8 @@
                 <div class="single-product-long-image-card">
                     <img class="single-product-image-long"
                          src="{% static image.iurl %}"
-                         alt="{{ product.title }}">
+                         alt="{{ product.title }}"
+                         loading="lazy">
                 </div>
             {% endif %}
         {% endfor %}

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -84,7 +84,11 @@
           <!-- Logo -->
           <div class="nav-logo">
             <a href="/"> 
-              <img src="{% static 'doobarashop/upload/images/logo-creation.png' %}" alt="home automation doobara">
+              <img src="{% static 'doobarashop/upload/images/logo-creation.png' %}"
+                   alt="home automation doobara"
+                   width="500"
+                   height="133"
+                   loading="eager">
             </a>
           </div>
 


### PR DESCRIPTION
### Motivation
- Reduce frontend image payload and improve perceived load times by using native browser lazy loading for non-critical images while keeping likely LCP/hero images eager. 
- Provide explicit `width`/`height` where intrinsic or layout-fixed dimensions are known to avoid layout shift.
- Make minimal, safe template-only changes without touching business or variant logic.

### Description
- Added `loading="lazy"` to non-critical images in listing carousels, system cards, shop grid cards, blog list cards, gallery thumbnails, and long product images (files modified: `shop/templates/shop/index.html`, `shop/templates/shop/shop.html`, `shop/templates/shop/single_product.html`, `blog/templates/blog/blog.html`).
- Kept above-the-fold / likely LCP images eager and added `fetchpriority="high"` to clear LCP candidates: homepage hero phone visual and single-product main images (file modified: `shop/templates/shop/index.html`, `shop/templates/shop/single_product.html`).
- Added explicit `width` and `height` attributes where image sizes were known or layout-fixed (logo, homepage phone image, square product card slots, single-product main gallery and thumbnails) to reduce CLS (files modified: `templates/doobarashop/layout.html`, `shop/templates/shop/index.html`, `shop/templates/shop/shop.html`, `shop/templates/shop/single_product.html`).
- Improved blog markup by adding missing `alt` text and appropriate loading hints (files modified: `blog/templates/blog/blog.html`, `blog/templates/blog/single_blog_post.html`).
- No image `src` paths changed, no JS lazy-loading libraries added, and no business/variant/checkout logic changed.

### Testing
- Ran `python manage.py check` in this environment which failed due to missing environment configuration: `ValueError: SECRET_KEY is not set`, so full Django checks could not run here (expected for this sandbox).
- Ran a small automated Python check using Pillow to inspect intrinsic image sizes for `static/doobarashop/upload/images/phone-app-screen.png` and `static/doobarashop/upload/images/logo-creation.png` which succeeded and was used to set `width`/`height` for those images.
- Automated template diffs were inspected (`git diff` of modified templates) to verify the expected attribute additions and were committed successfully.

Areas flagged for later work (no code changes now):
- Add `srcset`/`sizes` or server-generated responsive thumbnails to further reduce bandwidth on mobile; many templates still serve single-source images.
- Some blog static images referenced in templates were not present in the local static path during checks; confirm static asset pipeline / image derivatives in deployment.

Files changed (exact):
- `shop/templates/shop/index.html`
- `shop/templates/shop/shop.html`
- `shop/templates/shop/single_product.html`
- `blog/templates/blog/blog.html`
- `blog/templates/blog/single_blog_post.html`
- `templates/doobarashop/layout.html`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96cf66d908324a701ba7d847d2bb7)