### PR TITLE
Add Desk Lamps and Smart Devices filters to shop tabs

### DIFF
--- a/shop/templates/shop/shop.html
+++ b/shop/templates/shop/shop.html
@@ -50,6 +50,10 @@
     <div class="shop-tabs" data-shop-tabs>
         <button class="shop-tabs__btn" type="button" data-tab="products" aria-pressed="true">All Products</button>
         <button class="shop-tabs__btn" type="button" data-tab="systems" aria-pressed="false">Systems</button>
+        <!-- New desk-lamp tab: keeps filtering in the same JS tab system without changing layout structure. -->
+        <button class="shop-tabs__btn" type="button" data-tab="desk-lamps" aria-pressed="false">Desk Lamps</button>
+        <!-- New smart-devices tab: uses client-side category/system markers already rendered on cards. -->
+        <button class="shop-tabs__btn" type="button" data-tab="smart-devices" aria-pressed="false">Smart Devices</button>
     </div>
     </div>
 
@@ -57,7 +61,10 @@
     <div class="shop-grid">
         {% for row in lop %}
             {% if row.active %}
-                <article class="shop-card" data-system="{{ row.system|yesno:'true,false' }}">
+                <article class="shop-card"
+                         data-system="{{ row.system|yesno:'true,false' }}"
+                         {# Category marker used by JS tabs for Desk Lamps / Smart Devices filtering. #}
+                         data-category="{% if row.pcategory.0 %}{{ row.pcategory.0.name|lower }}{% endif %}">
                     <a href="{{ row.url }}" class="shop-card__link">
 
                         <div class="shop-card__media">

--- a/static/doobarashop/js/features/shopTabs.js
+++ b/static/doobarashop/js/features/shopTabs.js
@@ -12,14 +12,32 @@ export function initShopTabs() {
   }
 
   // for URL query param, if we want to link to a specific tab
-  const validTabs = ['products', 'systems'];
+  // Keep the same tab-driven architecture, but allow the two new product-only filters.
+  const validTabs = ['products', 'systems', 'desk-lamps', 'smart-devices'];
 
   const filterCards = (selectedTab) => {
-    const shouldShowSystem = selectedTab === 'systems';
-
     cards.forEach((card) => {
       const isSystem = card.dataset.system === 'true';
-      card.style.display = isSystem === shouldShowSystem ? '' : 'none';
+      // Category marker comes from template data-category and is normalized to lowercase there.
+      const category = card.dataset.category || '';
+      let shouldShow = false;
+
+      if (selectedTab === 'systems') {
+        // Existing behavior: systems tab shows only system products.
+        shouldShow = isSystem;
+      } else if (selectedTab === 'products') {
+        // Existing behavior: all products tab shows non-system products.
+        shouldShow = !isSystem;
+      } else if (selectedTab === 'desk-lamps') {
+        // New behavior: desk-lamps tab shows only non-system products in Desk Lamp category.
+        shouldShow = !isSystem && category === 'desk lamp';
+      } else if (selectedTab === 'smart-devices') {
+        // New behavior: smart-devices is the safe fallback bucket for non-system, non-desk-lamp products.
+        // Assumption: if there is no explicit smart-device category marker, all remaining non-system products are smart devices.
+        shouldShow = !isSystem && category !== 'desk lamp';
+      }
+
+      card.style.display = shouldShow ? '' : 'none';
     });
 
     tabs.forEach((tab) => {
@@ -28,7 +46,7 @@ export function initShopTabs() {
     });
   };
 
-  // Check URL for ?tab=systems or ?tab=products to set initial state
+  // Check URL for known tab values (including new tabs) to set initial state
   const getInitialTab = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const tab = urlParams.get('tab');
@@ -43,7 +61,7 @@ export function initShopTabs() {
 
   tabs.forEach((tab) => {
     tab.addEventListener('click', () => {
-      // dataset.tab is either 'products' or 'systems'
+      // dataset.tab is one of the values in validTabs.
       const selectedTab = tab.dataset.tab;
       filterCards(selectedTab);
       // URL UPDATE


### PR DESCRIPTION
### Motivation
- Provide two additional client-side filters in the existing shop tab UI so customers can quickly view `Desk Lamps` and `Smart Devices` without touching backend logic.
- Reuse the current tab/button JS structure and server-rendered product metadata to keep changes minimal and safe.

### Description
- Added two new tab buttons in `shop/templates/shop/shop.html`: `data-tab="desk-lamps"` and `data-tab="smart-devices"`, with inline comments explaining their purpose.
- Added a minimal `data-category` attribute on each `.shop-card` in `shop/templates/shop/shop.html` (normalized to lowercase) so client-side JS can detect product categories without changing backend models. The template change includes a comment describing the marker.
- Extended `initShopTabs` in `static/doobarashop/js/features/shopTabs.js` to include the new tab names in `validTabs` and to apply category-aware filtering logic for `desk-lamps` and `smart-devices`, while preserving existing `systems` and `products` behavior; all new logic sections include explanatory comments and a documented fallback assumption for `smart-devices`.
- Kept HTML/CSS classes and layout intact and did not modify `style.css` or backend business logic to minimize risk.

### Testing
- Ran `node --check static/doobarashop/js/features/shopTabs.js` to validate the modified JS syntax and it passed. 
- Attempted `python manage.py check` but it could not run in this environment because the Django `SECRET_KEY` is not set, so Django checks were not completed.
- No automated UI tests were available in this environment; the change is designed to be client-side only and should be manually smoke-tested in the browser to confirm tab filtering behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca81cd841883249fb383b6fde350d5)