### PR TITLE
Add reCAPTCHA protection to allauth signup and login

### DIFF
--- a/doobara/settings.py
+++ b/doobara/settings.py
@@ -79,6 +79,8 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
     'allauth.socialaccount.providers.facebook',
+    # Enables django-recaptcha form fields/widgets used by allauth forms.
+    'captcha',
     'import_export',
     'phonenumber_field'
 ]
@@ -302,7 +304,12 @@ SIGNUP_REDIRECT_URL = '/'
 
 ACCOUNT_FORMS = {
 'signup': 'users.forms.CustomSignupForm',
+'login': 'users.forms.CustomLoginForm',
 }
+
+# reCAPTCHA keys are environment-driven so secrets stay out of source control.
+RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY", "")
+RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY", "")
 
 # allauth email and username authentication
 ACCOUNT_LOGIN_METHODS = {'email', 'username'}

--- a/users/forms.py
+++ b/users/forms.py
@@ -7,12 +7,17 @@ from django.utils.translation import gettext_lazy as _
 from users.models import *
 from datetime import datetime
 from allauth.account.forms import SignupForm
+from allauth.account.forms import LoginForm
 from django.core.validators import MaxValueValidator
+from captcha.fields import ReCaptchaField
+from captcha.widgets import ReCaptchaV2Checkbox
 # from phonenumber_field.modelfields import PhoneNumberField
 
 
 
 class CustomSignupForm(SignupForm):
+    # Adds a server-validated reCAPTCHA challenge to the allauth signup flow.
+    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)
     first_name = forms.CharField(max_length=30, label='First Name')
     last_name = forms.CharField(max_length=30, label='Last Name')
 
@@ -28,6 +33,11 @@ class CustomSignupForm(SignupForm):
 
         # You must return the original result.
         return user
+
+
+class CustomLoginForm(LoginForm):
+    # Adds a server-validated reCAPTCHA challenge to the allauth login flow.
+    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)
         
 # class Delivery_Information(forms.Form):
 #     first_name = forms.CharField(widget=forms.TextInput() ,max_length=30, required=True)

--- a/users/templates/account/login.html
+++ b/users/templates/account/login.html
@@ -96,7 +96,21 @@
                     {% csrf_token %}
 
                     <div class="auth-form__fields">
-                        {{ form.as_p }}
+                        {# Includes required JS/CSS for widget-based fields such as reCAPTCHA. #}
+                        {{ form.media }}
+                        {# Keeps allauth non-field validation errors visible above input fields. #}
+                        {{ form.non_field_errors }}
+                        {# Render fields explicitly so the captcha block stays predictable in the auth layout. #}
+                        {% for field in form %}
+                            <p>
+                                {{ field.label_tag }}
+                                {{ field }}
+                                {% if field.help_text %}
+                                    <small>{{ field.help_text }}</small>
+                                {% endif %}
+                                {{ field.errors }}
+                            </p>
+                        {% endfor %}
                     </div>
 
                     {% if redirect_field_value %}

--- a/users/templates/account/signup.html
+++ b/users/templates/account/signup.html
@@ -93,7 +93,21 @@
                     {% csrf_token %}
 
                     <div class="auth-form__fields">
-                        {{ form.as_p }}
+                        {# Includes required JS/CSS for widget-based fields such as reCAPTCHA. #}
+                        {{ form.media }}
+                        {# Keeps allauth non-field validation errors visible above input fields. #}
+                        {{ form.non_field_errors }}
+                        {# Render fields explicitly so the captcha block stays predictable in the auth layout. #}
+                        {% for field in form %}
+                            <p>
+                                {{ field.label_tag }}
+                                {{ field }}
+                                {% if field.help_text %}
+                                    <small>{{ field.help_text }}</small>
+                                {% endif %}
+                                {{ field.errors }}
+                            </p>
+                        {% endfor %}
                     </div>
 
                     {% if redirect_field_value %}


### PR DESCRIPTION
### Motivation
- Prevent automated/bot abuse on authentication endpoints by adding server-validated reCAPTCHA to signup and login with minimal, focused changes that reuse the existing allauth extension points.
- Keep configuration environment-driven and preserve the existing .env loading, social login buttons, and overall auth flow/layout.

### Description
- Added `'captcha'` to `INSTALLED_APPS` and added `RECAPTCHA_PUBLIC_KEY` and `RECAPTCHA_PRIVATE_KEY` settings read from environment variables so keys are not hardcoded (`doobara/settings.py`).
- Extended the existing `CustomSignupForm` with a `ReCaptchaField(widget=ReCaptchaV2Checkbox)` and added a new `CustomLoginForm(LoginForm)` with the same `ReCaptchaField` to enforce server-side validation via `django-recaptcha` (`users/forms.py`).
- Wired both custom forms into allauth by adding `'login': 'users.forms.CustomLoginForm'` alongside the existing signup mapping in `ACCOUNT_FORMS` so allauth uses the overridden forms (`doobara/settings.py`).
- Updated the signup and login templates to render `{{ form.media }}`, `{{ form.non_field_errors }}` and explicit field markup instead of `{{ form.as_p }}` so the widget and its assets render predictably in the current auth layout while preserving social login UI (`users/templates/account/signup.html`, `users/templates/account/login.html`).

### Testing
- Ran `python manage.py check` in the container and it failed due to the environment missing `SECRET_KEY` (expected for this ephemeral environment). 
- Ran `SECRET_KEY=dummy RECAPTCHA_PUBLIC_KEY=dummy RECAPTCHA_PRIVATE_KEY=dummy python manage.py check` to simulate runtime keys and it failed with `ModuleNotFoundError: No module named 'captcha'`, indicating `django-recaptcha` is not importable in this execution environment; this failure is environment-specific and not a code regression.
- No other automated test suites were run in this environment; code changes were committed locally after the above validations.

Notes: after deploying these changes you must set `RECAPTCHA_PUBLIC_KEY` and `RECAPTCHA_PRIVATE_KEY` in your environment (or .env) and ensure `django-recaptcha` is installed in the runtime environment so the project can import `captcha` and render/validate widgets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caab770c848324aad9256bbb3728aa)