### PR TITLE
Harden order flow and fix allauth provider config

### DIFF
--- a/doobara/settings.py
+++ b/doobara/settings.py
@@ -263,16 +263,10 @@ AUTHENTICATION_BACKENDS = [
 # allauth google 
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
-        'SCOPE': ['profile','email',],
-        'AUTH_PARAMS': {'access_type': 'offline',},
-        'LOGIN_ON_GET': True
-    }
-}
-SOCIALACCOUNT_LOGIN_ON_GET = True
-
-
-
-SOCIALACCOUNT_PROVIDERS = {
+        'SCOPE': ['profile', 'email'],
+        'AUTH_PARAMS': {'access_type': 'offline'},
+        'LOGIN_ON_GET': True,
+    },
     'facebook': {
         'METHOD': 'oauth2',
         'SCOPE': ['email', 'public_profile'],
@@ -293,6 +287,7 @@ SOCIALACCOUNT_PROVIDERS = {
         'GRAPH_API_URL': 'https://graph.facebook.com/v13.0',
     }
 }
+SOCIALACCOUNT_LOGIN_ON_GET = True
 # all auth id 
 
 SITE_ID = 2

--- a/users/modules/ordermanager.py
+++ b/users/modules/ordermanager.py
@@ -67,7 +67,9 @@ def createorder(request, form, new):
         # current saved in data address
         id = int(form['current_address_id'])
         note = form.get('ordernote', '').strip()
-        delivery = Delivery_Address_Details.objects.get(id=id)
+        # Security: lock address selection to the authenticated user so posted
+        # IDs cannot attach someone else's saved address to this order.
+        delivery = Delivery_Address_Details.objects.get(id=id, user=user)
         
     # Shipping method can come from checkout POST; persist selection first so totals stay deterministic.
     shipping_method_id = request.POST.get("shipping_method_id")
@@ -136,16 +138,16 @@ def address_post(form):
     return form, state
             
 def change_default_address(user, aid):
-    # get current default addres and set it to default to false and and save model instance
-    # loc: models
-    old = Delivery_Address_Details.objects.get(user=user, default=True)
-    old.default = False
-    old.save()
-    # set new address to default 
-    # get new address and set default to true and save instance
-    caddress = Delivery_Address_Details.objects.get(id=aid)
+    # Clear current default only when it exists so first-time default assignment
+    # cannot fail with DoesNotExist.
+    old = Delivery_Address_Details.objects.filter(user=user, default=True).first()
+    if old:
+        old.default = False
+        old.save(update_fields=["default"])
+    # Security: only allow switching defaults within the same user's addresses.
+    caddress = Delivery_Address_Details.objects.get(id=aid, user=user)
     caddress.default = True
-    caddress.save()
+    caddress.save(update_fields=["default"])
 
 
 def create_new_address(request, form):

--- a/users/views.py
+++ b/users/views.py
@@ -33,6 +33,10 @@ def myaccount(request):
 # Create a new order instance
 @login_required
 def placeorder(request):
+    if request.method != "POST":
+        # placeorder is a write endpoint; redirect non-POST access to checkout.
+        return redirect("checkout")
+
     if request.method == "POST":
         # is dictionarry form
         form =request.POST 
@@ -99,23 +103,26 @@ def placeorder(request):
 # render specific order instance and connected items
 @login_required
 def order_log(request):
-    if request.method == "POST":
-        # is int | HTML submited data 
-        # given order record id 
-        orderid = request.POST['orderid']
-        # is object  | (loc: models)
-        # order instance the first in list 
-        # Security: ensure users can only access their own orders.
-        order = get_object_or_404(Orders, id=orderid, user=request.user)
-        # is list of instance 
-        # all order connected product item records 
-        items = order.items.all()
-        # is dict 
-        # serilized copy of order record fields
-        sorder = order.serialize()
-        # is list of dict 
-        # list of serialized copy of order item record objects list
-        sitems = [item.serialize() for item in items]
+    if request.method != "POST":
+        # Keep endpoint predictable: account page submits POST order IDs.
+        return redirect("myaccount")
+
+    # is int | HTML submited data 
+    # given order record id 
+    orderid = request.POST['orderid']
+    # is object  | (loc: models)
+    # order instance the first in list 
+    # Security: ensure users can only access their own orders.
+    order = get_object_or_404(Orders, id=orderid, user=request.user)
+    # is list of instance 
+    # all order connected product item records 
+    items = order.items.all()
+    # is dict 
+    # serilized copy of order record fields
+    sorder = order.serialize()
+    # is list of dict 
+    # list of serialized copy of order item record objects list
+    sitems = [item.serialize() for item in items]
 
     return render(request, "users/orderlog.html", {"order": sorder, "items": sitems})
 


### PR DESCRIPTION
### Motivation
- Remove launch-blocking and security-risk behaviors in core account and purchase flows by enforcing ownership, avoiding unsafe assumptions, and fixing social-login config collisions.
- Keep changes minimal and focused on correctness and production stability without altering business logic or variant handling.

### Description
- Merge duplicated `SOCIALACCOUNT_PROVIDERS` blocks and preserve both Google and Facebook provider settings so one provider configuration no longer overwrites the other in `doobara/settings.py`.
- Constrain selected delivery addresses on order creation to the authenticated user by changing `Delivery_Address_Details.objects.get(id=id)` to `Delivery_Address_Details.objects.get(id=id, user=user)` in `users/modules/ordermanager.py` to prevent cross-user address injection.
- Make default-address switching robust by clearing an existing default with a safe `filter(...).first()` check and enforcing ownership when setting the new default in `users/modules/ordermanager.py`.
- Make `placeorder` and `order_log` endpoints reject non-POST access with safe redirects (`redirect("checkout")` / `redirect("myaccount")`) in `users/views.py` to avoid undefined-variable paths and accidental GET misuse.

### Testing
- Ran `python manage.py check --deploy` with a temporary environment, which completed with no issues after the fixes.
- Ran `python manage.py check` in development mode, which completed with no issues.
- Ran `python manage.py test`, which executed the test suite and reported `OK` (4 tests ran and passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cada1d76b88324873fddb31193802b)