### PR TITLE
Harden checkout and auth flows for production launch

### DIFF
--- a/cart/views.py
+++ b/cart/views.py
@@ -48,8 +48,7 @@ def shopaddtocart(request):
         cm.add_to_cart(cpid)
         # is dict | (loc: modules.cartmanager)
         # current cart data in dict 
-        ccart = cartcontext(request) 
-        print(ccart)
+        ccart = cartcontext(request)
         return JsonResponse({"result":"done", "cart": ccart}, status=201)
 
 # caller: cart

--- a/doobara/urls.py
+++ b/doobara/urls.py
@@ -44,9 +44,10 @@ urlpatterns = [
     path("", include("users.urls")),
     path("", include("blog.urls")),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
-    path('sentry-debug/', trigger_error)
 ]
 
 
 if settings.DEBUG:
+    # Keep Sentry's intentional crash route strictly in debug environments.
+    urlpatterns += [path('sentry-debug/', trigger_error)]
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/users/hashers.py
+++ b/users/hashers.py
@@ -1,8 +1,5 @@
 from django.contrib.auth.hashers import BasePasswordHasher
-from passlib.hash import phpass as wp_hash  # <-- THIS is the right one
-
-
-print("### users.hashers module imported ###")  # debug: should print once when Django starts
+from passlib.hash import phpass as wp_hash
 
 
 class WordPressPasswordHasher(BasePasswordHasher):
@@ -14,7 +11,6 @@ class WordPressPasswordHasher(BasePasswordHasher):
     We rely on passlib's `phpass`, which is compatible with WordPress'
     $P$ hashes.
     """
-    print("### WordPressPasswordHasher class loaded ###")  # debug: should print once when Django starts
     algorithm = "wordpress"
 
     def salt(self):
@@ -33,19 +29,12 @@ class WordPressPasswordHasher(BasePasswordHasher):
         return f"{self.algorithm}${raw}"
 
     def verify(self, password, encoded):
-        # DEBUG: this should print when check_password() uses this hasher
-        print(">>> WordPressPasswordHasher.verify CALLED")
-        print("    password:", repr(password))
-        print("    encoded:", repr(encoded))
-
         try:
             algorithm, rest = encoded.split("$", 1)
         except ValueError:
-            print("    ! Could not split encoded string:", encoded)
             return False
 
         if algorithm != self.algorithm:
-            print("    ! Algorithm mismatch:", algorithm)
             return False
 
         # rest may be "$P$..." (your current DB) or "P$..." depending on import
@@ -54,15 +43,11 @@ class WordPressPasswordHasher(BasePasswordHasher):
         elif rest.startswith("P$"):
             wp_encoded = "$" + rest
         else:
-            print("    ! Not a valid WP hash segment:", rest)
             return False
 
-        ok = wp_hash.verify(password, wp_encoded)
-        print("    verify result:", ok)
-        return ok
+        return wp_hash.verify(password, wp_encoded)
 
     def must_update(self, encoded):
-        print(">>> WordPressPasswordHasher.must_update CALLED")
         # After a successful login, rehash using Django's default hasher
         return True
 

--- a/users/modules/ordermanager.py
+++ b/users/modules/ordermanager.py
@@ -7,6 +7,13 @@ from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
 
 
+def _build_checkout_error_form(message):
+    # Centralize non-field checkout errors so caller can re-render checkout safely.
+    form = Delivery_Information()
+    form.add_error(None, message)
+    return form
+
+
 def _build_order_item_snapshot(cart_item):
     # NEW: Build an immutable purchase snapshot from the exact cart selection
     # so historical orders do not fall back to mutable parent-product defaults.
@@ -38,6 +45,10 @@ def _build_order_item_snapshot(cart_item):
 
 def createorder(request, form, new):
     user = request.user
+    cart_items = list(user.mycart.items.select_related("product", "variant", "normal_variant"))
+    if not cart_items:
+        return (False, _build_checkout_error_form("Your cart is empty. Please add products before placing an order."))
+
     # result = create_new_address(request, form)
     if new:
         if form.is_valid():
@@ -69,7 +80,10 @@ def createorder(request, form, new):
         note = form.get('ordernote', '').strip()
         # Security: lock address selection to the authenticated user so posted
         # IDs cannot attach someone else's saved address to this order.
-        delivery = Delivery_Address_Details.objects.get(id=id, user=user)
+        try:
+            delivery = Delivery_Address_Details.objects.get(id=id, user=user)
+        except Delivery_Address_Details.DoesNotExist:
+            return (False, _build_checkout_error_form("Selected delivery address is invalid. Please choose an address again."))
         
     # Shipping method can come from checkout POST; persist selection first so totals stay deterministic.
     shipping_method_id = request.POST.get("shipping_method_id")
@@ -99,8 +113,6 @@ def createorder(request, form, new):
             shipping_price=shipping_price,
         )
 
-        # NEW: Prefetch variant relations used by purchase snapshot selection logic.
-        cart_items = list(user.mycart.items.select_related("product", "variant", "normal_variant"))
         # NEW: Convert each cart row into a variant-aware immutable purchase snapshot.
         item_snapshots = [_build_order_item_snapshot(item) for item in cart_items]
         Item_Order.objects.bulk_create(

--- a/users/templates/account/signup.html
+++ b/users/templates/account/signup.html
@@ -61,7 +61,7 @@
 
                 {% if socialaccount_providers %}
                     <div class="auth-social">
-                        <a class="auth-social__btn auth-social__btn--google" href="/accounts/google/login">
+                        <a class="auth-social__btn auth-social__btn--google" href="{% provider_login_url 'google' process='login' %}">
                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="44" height="44" viewBox="0 0 48 48">
                                 <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"></path>
                                 <path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"></path>
@@ -73,7 +73,7 @@
                         </a>
 
                         <a class="auth-social__btn auth-social__btn--facebook"
-                           href="{% provider_login_url 'facebook' method='js_sdk' %}">
+                           href="{% provider_login_url 'facebook' process='login' %}">
                              <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="44" height="44" viewBox="0 0 48 48">
                                 <path fill="#3F51B5" d="M42,37c0,2.762-2.238,5-5,5H11c-2.761,0-5-2.238-5-5V11c0-2.762,2.239-5,5-5h26c2.762,0,5,2.238,5,5V37z"></path>
                                 <path fill="#FFF" d="M34.368,25H31v13h-5V25h-3v-4h3v-2.41c0.002-3.508,1.459-5.59,5.592-5.59H35v4h-2.287C31.104,17,31,17.6,31,18.723V21h4L34.368,25z"></path>


### PR DESCRIPTION
### Motivation
- Reduce launch risk by removing noisy debug output and closing accidental production attack/sandbox routes. 
- Prevent bad order records or 500s from empty-cart checkouts or invalid saved-address IDs. 
- Make social signup/login button behavior consistent with the login page to avoid provider URL mismatches.

### Description
- Remove debug prints from cart add-to-cart path to avoid leaking request data in logs (`cart/views.py`).
- Remove debug prints from the WordPress-compatible password hasher and return verification result directly to avoid noisy auth logs (`users/hashers.py`).
- Restrict the Sentry crash endpoint (`/sentry-debug/`) so it is only added to `urlpatterns` when `DEBUG=True` (`doobara/urls.py`).
- Harden order creation: add an early empty-cart guard, validate posted saved-address IDs and return a non-field form error instead of raising, and centralize a small helper to produce a checkout error form (`users/modules/ordermanager.py`).
- Normalize social signup provider links on the signup page to use `provider_login_url` with `process='login'` for parity with the login page (`users/templates/account/signup.html`).
- Changes are intentionally minimal and safe; no model/schema changes were made and product/system variant logic was preserved.

Files changed: `cart/views.py`, `users/hashers.py`, `doobara/urls.py`, `users/modules/ordermanager.py`, `users/templates/account/signup.html`.

### Testing
- Compiled modified files with `python -m compileall cart/views.py doobara/urls.py users/hashers.py users/modules/ordermanager.py` and compilation succeeded for all updated modules. (✅)
- Ran `python manage.py check` in this execution environment but it failed to run due to a missing `SECRET_KEY` in the environment; this is an environment issue and not caused by the changes. (⚠️)
- Manual inspection and small runtime sanity checks performed on templates and JS integration points that interact with the modified endpoints and data attributes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb91ca61508324b509455470085b31)