### PR TITLE
Fix Google Merchant CSV price formatting with currency

### DIFF
--- a/shop/modeling/feed_export.py
+++ b/shop/modeling/feed_export.py
@@ -213,7 +213,17 @@ def product_feed_queryset():
 # NEW: Shared purchasable-offer expansion.
 # We emit one row per actual selectable option when variants/tiers exist, and one
 # row for simple products. This avoids ambiguous parent-level rows.
-def _iter_feed_offers(request):
+def _google_price(amount, currency):
+    # Google Merchant requires the `price` field to include amount + ISO currency
+    # in one value (e.g., "15.00 USD"). Returning None keeps invalid rows honest.
+    normalized_amount = _normalized_price(amount)
+    normalized_currency = (currency or "").strip().upper()
+    if not normalized_amount or not normalized_currency:
+        return None
+    return f"{normalized_amount} {normalized_currency}"
+
+
+def _iter_feed_offers(request, *, google_price_format=False):
     for product in product_feed_queryset():
         base_description = _plain_text_description(
             product.short_description or product.description
@@ -243,7 +253,11 @@ def _iter_feed_offers(request):
                     "description": offer_description,
                     "availability": "in stock" if inventory["in_stock"] else "out of stock",
                     "condition": base_condition,
-                    "price": _normalized_price(variant.sale_price or variant.price),
+                    "price": (
+                        _google_price(variant.sale_price or variant.price, variant.currency)
+                        if google_price_format
+                        else _normalized_price(variant.sale_price or variant.price)
+                    ),
                     "link": base_link,
                     "image_link": image_url,
                     "brand": base_brand,
@@ -272,7 +286,14 @@ def _iter_feed_offers(request):
                     "description": offer_description,
                     "availability": base_availability,
                     "condition": base_condition,
-                    "price": _normalized_price(variant.sale_price or variant.price),
+                    "price": (
+                        _google_price(
+                            variant.sale_price or variant.price,
+                            getattr(variant, "currency", None) or product.currency,
+                        )
+                        if google_price_format
+                        else _normalized_price(variant.sale_price or variant.price)
+                    ),
                     "link": base_link,
                     "image_link": image_url,
                     "brand": base_brand,
@@ -288,7 +309,11 @@ def _iter_feed_offers(request):
             "description": base_description,
             "availability": base_availability,
             "condition": base_condition,
-            "price": _normalized_price(product.sale_price or product.price),
+            "price": (
+                _google_price(product.sale_price or product.price, product.currency)
+                if google_price_format
+                else _normalized_price(product.sale_price or product.price)
+            ),
             "link": base_link,
             "image_link": _absolute_image_url(request, product),
             "brand": base_brand,
@@ -298,13 +323,13 @@ def _iter_feed_offers(request):
 
 
 # NEW: Shared CSV response builder for scheduled catalog fetches.
-def build_catalog_csv_response(request, *, filename):
+def build_catalog_csv_response(request, *, filename, google_price_format=False):
     response = HttpResponse(content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = f'inline; filename="{filename}"'
 
     writer = csv.DictWriter(response, fieldnames=_CSV_FIELDS, extrasaction="ignore")
     writer.writeheader()
-    for row in _iter_feed_offers(request):
+    for row in _iter_feed_offers(request, google_price_format=google_price_format):
         writer.writerow(row)
 
     return response

--- a/shop/views.py
+++ b/shop/views.py
@@ -379,7 +379,11 @@ def google_product_feed_csv(request):
     NEW: Public CSV endpoint for Google Merchant Center scheduled fetches.
     Keeps feed generation centralized in modeling.feed_export.
     """
-    return build_catalog_csv_response(request, filename="google-product-feed.csv")
+    return build_catalog_csv_response(
+        request,
+        filename="google-product-feed.csv",
+        google_price_format=True,
+    )
 
 
 def meta_catalog_feed_csv(request):


### PR DESCRIPTION
### Motivation
- Google Merchant requires the `price` column to include both amount and ISO 4217 currency (for example `15.00 USD`) but the CSV previously emitted only the numeric amount. 
- The change should be minimal and only affect the Google CSV export path while preserving existing Meta feed behavior. 

### Description
- Added a small helper ` _google_price(amount, currency)` in `shop/modeling/feed_export.py` that returns `"<amount> <CURRENCY>"` or `None` for invalid inputs. 
- Updated `_iter_feed_offers()` to accept a `google_price_format` flag and emit Google-formatted prices when enabled. 
- Ensured currency sources follow existing model fields: simple products use `product.currency`, normal variants use `variant.currency` if present otherwise `product.currency`, and system variants use `variant.currency`. 
- Extended `build_catalog_csv_response()` with a `google_price_format` parameter and enabled it in the Google feed view `google_product_feed_csv` in `shop/views.py`; Meta feed remains unchanged. 
- Files changed: `shop/modeling/feed_export.py` and `shop/views.py`. 

### Testing
- Running `python manage.py check` in this environment failed due to the missing environment variable `SECRET_KEY`, which is expected for local CI-less runs. 
- Applied migrations in an isolated SQLite DB with `SECRET_KEY=dev DEBUG=1 DB_ENGINE=django.db.backends.sqlite3 DB_NAME=/tmp/doobara_feed_test.sqlite3` and migration run succeeded. 
- Seeded test data via a shell script and exercised `_iter_feed_offers(..., google_price_format=True)` and `google_price_format=False`, confirming Google-mode outputs: `15.00 USD`, `9.00 USD`, `42.00 USD` and Meta-mode remained numeric-only: `15.00`, `9.00`, `42.00`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd093ed7d08324b378b92408eed3cc)