### PR TITLE
Fix coupon action button wrapping and spacing in cart/checkout

### DIFF
--- a/cart/sass/pages/_cart.scss
+++ b/cart/sass/pages/_cart.scss
@@ -216,6 +216,7 @@
     justify-content: space-between;
     gap: 16px;
     flex-wrap: wrap;
+    align-items: flex-start;
 }
 
 .cart-coupon {
@@ -230,16 +231,21 @@
     display: flex;
     gap: 10px;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .cart-coupon form:first-child {
     flex: 1 1 320px;
 }
 
+.cart-coupon form:last-child {
+    flex: 0 0 auto;
+}
+
 .cart-coupon input {
     @include var.form-control(var.$text-color-black, white, #dbe7f3, 50px);
     flex: 1;
-    min-width: 180px;
+    min-width: 220px;
     font-size: 0.96rem;
 }
 
@@ -259,6 +265,8 @@
 .cart-update-btn {
     min-height: 50px;
     padding: 0 20px;
+    white-space: nowrap;
+    flex: 0 0 auto;
 }
 
 .cart-coupon button {
@@ -271,14 +279,21 @@
     width: 100%;
     font-size: 0.9rem;
     line-height: 1.5;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid transparent;
 }
 
 .cart-coupon-feedback {
     color: var.$text-color-gray;
+    background: rgba(12, 74, 110, 0.05);
+    border-color: rgba(12, 74, 110, 0.12);
 }
 
 .cart-coupon-error {
     color: #d32f2f;
+    background: rgba(211, 47, 47, 0.07);
+    border-color: rgba(211, 47, 47, 0.2);
 }
 
 .cart-update-btn {
@@ -488,6 +503,11 @@
 
     .cart-coupon {
         flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cart-coupon form {
+        width: 100%;
     }
 
     .cart-coupon button,

--- a/cart/sass/pages/_checkout.scss
+++ b/cart/sass/pages/_checkout.scss
@@ -161,10 +161,17 @@
     flex-wrap: wrap;
 }
 
+.checkout-notes > div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: flex-start;
+}
+
 .checkout-notes input[type="text"] {
     @include var.form-control(var.$ui-text, var.$ui-white, #dbe7f3, 50px);
     flex: 1;
-    min-width: 180px;
+    min-width: 220px;
 }
 
 .checkout-notes input[type="text"]:focus {
@@ -176,14 +183,21 @@
     margin: 8px 0 0;
     font-size: 0.9rem;
     line-height: 1.5;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid transparent;
 }
 
 .checkout-coupon-feedback {
     color: var.$ui-text-soft;
+    background: rgba(12, 74, 110, 0.05);
+    border-color: rgba(12, 74, 110, 0.12);
 }
 
 .checkout-coupon-error {
     color: #d32f2f;
+    background: rgba(211, 47, 47, 0.07);
+    border-color: rgba(211, 47, 47, 0.2);
 }
 
 .checkout-shipping-methods {
@@ -236,6 +250,7 @@
 /* Buttons */
 .checkout-btn {
     @include var.action-button-base;
+    white-space: nowrap;
 }
 
 .checkout-btn:hover {
@@ -549,6 +564,10 @@
 
     .checkout-place-order-btn,
     .checkout-btn {
+        width: 100%;
+    }
+
+    .checkout-notes > div form {
         width: 100%;
     }
 


### PR DESCRIPTION
### Motivation
- Coupon input and action buttons in cart and checkout were wrapping and shifting size after applying/removing coupons, causing layout instability and poor spacing.
- Keep fixes scoped to Sass so UI behavior is corrected without touching compiled `style.css` or backend logic.

### Description
- Adjusted cart actions layout to stabilize alignment by adding `align-items: flex-start` and enabling controlled wrapping for coupon forms in `cart/sass/pages/_cart.scss`.
- Prevented button and update controls from wrapping by setting `white-space: nowrap` and `flex: 0 0 auto` on action buttons, and ensured the remove form does not expand (`cart-coupon form:last-child`).
- Increased coupon input minimum width to `220px` and added matching changes in `cart/sass/pages/_checkout.scss` so input and button spacing is consistent across cart and checkout.
- Styled coupon feedback and error text with padding, subtle background and border-radius so messages are visually contained and do not push adjacent controls; improved mobile stacking so forms occupy full width at small breakpoints.

### Testing
- Ran repository commands `git status --short` and `git commit -m "Fix cart and checkout coupon action layout stability"` which completed successfully.
- No automated visual regression or unit tests for SCSS were available in CI for these changes, so only the commit/validation commands were executed successfully.
- Changes are CSS-only and do not modify backend code or templates, so no server-side tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f6005c5c832484fe14fdccb8c637)