### PR TITLE
Gate analytics, Meta Pixel, and reCAPTCHA to production

### DIFF
--- a/doobara/context_processors.py
+++ b/doobara/context_processors.py
@@ -51,6 +51,8 @@ def _get_canonical_url(request):
 
 def analytics_context(request):
     return {
+        # Only enable third-party tracking scripts outside of debug/local mode.
+        "TRACKING_ENABLED": not settings.DEBUG,
         "GOOGLE_ANALYTICS_ID": settings.GOOGLE_ANALYTICS_ID,
         "GOOGLE_SITE_VERIFICATION": settings.GOOGLE_SITE_VERIFICATION,
         # Meta Pixel id for template usage.

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -24,7 +24,7 @@
     {% if GOOGLE_SITE_VERIFICATION %}
     <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">
     {% endif %}
-    {% if GOOGLE_ANALYTICS_ID %}
+    {% if TRACKING_ENABLED and GOOGLE_ANALYTICS_ID %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -33,7 +33,7 @@
       gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
     </script>
     {% endif %}
-    {% if META_PIXEL_ID %}
+    {% if TRACKING_ENABLED and META_PIXEL_ID %}
     {# Meta Pixel: base code + PageView (global) #}
     <script>
       !function(f,b,e,v,n,t,s)
@@ -62,7 +62,7 @@
   </head>
 
   <body>
-    {% if META_PIXEL_ID %}
+    {% if TRACKING_ENABLED and META_PIXEL_ID %}
     {# Meta Pixel: noscript fallback #}
     <noscript>
       <img height="1" width="1" style="display:none"

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.forms import ModelForm
 from allauth.account.forms import LoginForm, SignupForm
 from django_recaptcha.fields import ReCaptchaField
@@ -10,7 +11,9 @@ from .models import Delivery_Address_Details
 
 class CustomSignupForm(SignupForm):
     # Add captcha to signup to block automated account creation attempts.
-    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
+    if not settings.DEBUG:
+        # Only enforce reCAPTCHA in production-like environments.
+        captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
     first_name = forms.CharField(max_length=30, label='First Name')
     last_name = forms.CharField(max_length=30, label='Last Name')
 
@@ -30,7 +33,9 @@ class CustomSignupForm(SignupForm):
 
 class CustomLoginForm(LoginForm):
     # Add captcha to login to reduce credential stuffing/bot sign-in attempts.
-    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
+    if not settings.DEBUG:
+        # Only enforce reCAPTCHA in production-like environments.
+        captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
 
 class Delivery_Information(ModelForm):
     


### PR DESCRIPTION
### Motivation
- Prevent third-party tracking (Google Analytics / Meta Pixel) and reCAPTCHA from running in non-production/developer environments to avoid noisy telemetry and external dependency failures during local testing.
- Make template and form behavior explicit and environment-driven by reusing `DEBUG` to determine when to enable these features.

### Description
- Added `TRACKING_ENABLED = not settings.DEBUG` to the analytics context by updating `doobara/context_processors.py` so templates can gate tracking scripts.
- Updated `templates/doobarashop/layout.html` to render Google Analytics and Meta Pixel (including the noscript fallback) only when `TRACKING_ENABLED` is true and the corresponding IDs are present.
- Updated `users/forms.py` to only attach `ReCaptchaField` to `CustomSignupForm` and `CustomLoginForm` when `settings.DEBUG` is false, avoiding reCAPTCHA in development.

### Testing
- Ran `python -m compileall doobara users templates/doobarashop/layout.html` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fe78b3dc8324b20007410f4776f9)