### PR TITLE
Add footer and WhatsApp JS feature, wire initialization, and remove inline year script

### DIFF
--- a/static/doobarashop/js/bootstrap.js
+++ b/static/doobarashop/js/bootstrap.js
@@ -2,6 +2,7 @@ import { initAddressPopup } from './features/addressPopup.js';
 import { initCartActions } from './features/cartActions.js';
 import { initCheckoutTotals } from './features/checkoutTotals.js';
 import { initDefaultAddressSelection } from './features/defaultAddress.js';
+import { initFooterAndWhatsapp } from './features/footerAndWhatsapp.js';
 import { initMobileMenu } from './features/mobileMenu.js';
 import { initMobileSearch } from './features/mobileSearch.js';
 import { initProductGallery } from './features/productGallery.js';
@@ -20,4 +21,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initMobileSearch();
   initDefaultAddressSelection();
   initShopTabs();
+  initFooterAndWhatsapp();
 });

--- a/static/doobarashop/js/features/footerAndWhatsapp.js
+++ b/static/doobarashop/js/features/footerAndWhatsapp.js
@@ -1,0 +1,21 @@
+export function initFooterAndWhatsapp() {
+  const yearElement = document.getElementById('year');
+  if (yearElement) {
+    yearElement.textContent = String(new Date().getFullYear());
+  }
+
+  const whatsappHeaderLink = document.getElementById('whatsapp-header-link');
+  if (!whatsappHeaderLink) {
+    return;
+  }
+
+  const pageTitle = document.title ? document.title.trim() : '';
+  if (!pageTitle) {
+    return;
+  }
+
+  // Build a page-aware prefilled message so support can instantly see where the user came from.
+  const message = `Hi Doobara, I'm visiting: ${pageTitle}`;
+  const encodedMessage = encodeURIComponent(message);
+  whatsappHeaderLink.href = `${whatsappHeaderLink.href}?text=${encodedMessage}`;
+}

--- a/templates/doobarashop/layout.html
+++ b/templates/doobarashop/layout.html
@@ -101,6 +101,8 @@
           <div class="nav-right">
             <a href="https://wa.me/96170856471" 
               target="_blank" 
+              rel="noopener noreferrer"
+              id="whatsapp-header-link"
               class="whatsapp-btn">
                 WhatsApp
             </a>
@@ -189,9 +191,5 @@
       </footer>
     </div>
 
-    <script>
-      // just to keep the year auto-updated
-      document.getElementById("year").textContent = new Date().getFullYear();
-    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Centralize footer behaviors and WhatsApp link handling into a dedicated JS module to avoid inline scripts and keep behavior consistent across pages.
- Prefill the site WhatsApp header link with the current page title and add link security attributes to improve UX and security.

### Description
- Added a new module `static/doobarashop/js/features/footerAndWhatsapp.js` that sets the footer year and appends a page-aware prefilled message to the WhatsApp header link using the document title.
- Imported and initialized the new feature in `static/doobarashop/js/bootstrap.js` by adding `import { initFooterAndWhatsapp }` and calling `initFooterAndWhatsapp()` on `DOMContentLoaded`.
- Updated `templates/doobarashop/layout.html` to add `id="whatsapp-header-link"` and `rel="noopener noreferrer"` to the WhatsApp header anchor and removed the inline `<script>` that updated the year.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6007621e08324a460745dda76dea9)