### PR TITLE
Refactor Power Control System mobile-first purchase flow

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -116,6 +116,13 @@
     color: var.$ui-dark;
 }
 
+.single-product-promise {
+    margin: 0 0 14px;
+    color: var.$ui-text-soft;
+    line-height: 1.5;
+    font-size: 0.98rem;
+}
+
 .single-product-price-row {
     margin-bottom: 22px;
 }
@@ -404,6 +411,27 @@
     font-size: 0.95rem;
 }
 
+.system-variant-option__badge {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #fff;
+    background: var.$ui-primary;
+}
+
+.single-product-whatsapp-help {
+    display: inline-flex;
+    margin-top: 10px;
+    font-weight: 700;
+}
+
+.single-product-sticky-cart {
+    display: none;
+}
+
 .system-variant-package-items {
     list-style: none;
     padding: 0;
@@ -426,7 +454,86 @@
 }
 
 @media (max-width: 768px) {
+    .single-product-top {
+        gap: 14px;
+    }
+
+    .single-product-gallery {
+        padding: 14px;
+    }
+
+    .single-product-gallery__main {
+        max-height: 260px;
+        aspect-ratio: 4 / 3;
+        margin-bottom: 10px;
+    }
+
+    .single-product-gallery__main img {
+        width: 84%;
+        height: 84%;
+    }
+
+    .single-product-info {
+        padding-top: 18px;
+    }
+
     .system-variant-selector {
         grid-template-columns: 1fr;
+        margin: 12px 0;
+    }
+
+    .system-variant-option {
+        padding: 10px;
+    }
+
+    .single-product-sticky-cart {
+        position: fixed;
+        left: 12px;
+        right: 12px;
+        bottom: 12px;
+        z-index: 40;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 10px;
+        align-items: center;
+        padding: 10px;
+        border-radius: 14px;
+        background: #fff;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(12px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .single-product-page {
+        padding-bottom: 130px;
+    }
+
+    .single-product-sticky-cart.is-visible {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+    }
+
+    .single-product-sticky-cart__details {
+        display: grid;
+        gap: 2px;
+    }
+
+    .single-product-sticky-cart__tier {
+        font-weight: 700;
+        color: var.$ui-text;
+    }
+
+    .single-product-sticky-cart__price {
+        font-weight: 800;
+        color: var.$ui-primary;
+    }
+
+    .single-product-sticky-cart__button {
+        min-width: 140px;
+        height: 46px;
+        padding: 0 14px;
     }
 }

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -34,6 +34,7 @@
                 <div class="single-product-info">
                     <span class="single-product-info__eyebrow">Doobara System</span>
                     <h1 class="single-product-title">{{ product.title }}</h1>
+                    <p class="single-product-promise">Control key devices, monitor electricity usage, and automate your setup between EDL and generator.</p>
 
                     <div class="system-variant-selector" id="system-variant-selector">
                         {% for variant in system_variants %}
@@ -42,6 +43,7 @@
                                 class="system-variant-option {% if default_system_variant.id == variant.id %}is-active{% endif %}"
                                 data-variant-id="{{ variant.id }}">
                                 <span class="system-variant-option__tier">{{ variant.tier|title }}</span>
+                                {% if variant.tier|lower == "advanced" %}<span class="system-variant-option__badge">Recommended</span>{% endif %}
                                 <span class="system-variant-option__price">
                                     $ {% if variant.sale_price %}{{ variant.sale_price|floatformat:2 }}{% else %}{{ variant.price|floatformat:2 }}{% endif %}
                                 </span>
@@ -82,6 +84,7 @@
                             {% if not default_system_variant.can_purchase %}disabled{% endif %}>
                             {{ default_system_variant.cart_cta_label|default:"Out of Stock" }}
                         </button>
+                        <a class="single-product-whatsapp-help" href="https://wa.me/96170856471?text=I%27m%20interested%20in%20the%20Power%20Control%20System" target="_blank" rel="noopener">Need help choosing a tier? WhatsApp us</a>
                     </div>
 
                     <div class="single-product-specs">
@@ -93,6 +96,14 @@
 
             {{ system_variants|json_script:"variant-data" }}
             {{ default_system_variant.id|json_script:"default-variant-id" }}
+            <div class="single-product-sticky-cart" id="system-sticky-cart" aria-hidden="true">
+                <div class="single-product-sticky-cart__details">
+                    <span id="system-sticky-tier" class="single-product-sticky-cart__tier">{{ default_system_variant.tier|title }}</span>
+                    <span id="system-sticky-price" class="single-product-sticky-cart__price">$ {% if default_system_variant.sale_price %}{{ default_system_variant.sale_price|floatformat:2 }}{% else %}{{ default_system_variant.price|floatformat:2 }}{% endif %}</span>
+                </div>
+                <button type="button" id="system-sticky-addtocart" class="single-product-addtocart single-product-sticky-cart__button" {% if not default_system_variant.can_purchase %}disabled{% endif %}>{{ default_system_variant.cart_cta_label|default:"Out of Stock" }}</button>
+            </div>
+
         {% else %}
             <div class="single-product-top">
                 <!-- Left: gallery -->

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -78,10 +78,14 @@ function renderVariant(variant) {
   const packageItems = document.getElementById('system-variant-package-items');
   const addToCartButton = document.getElementById('spatc');
   const specifications = document.getElementById('longdescription');
+  const stickyTier = document.getElementById('system-sticky-tier');
+  const stickyPrice = document.getElementById('system-sticky-price');
+  const stickyButton = document.getElementById('system-sticky-addtocart');
 
   // NEW: System variant long description is pre-rendered HTML from server-side markdown conversion.
   if (specifications) specifications.innerHTML = variant.long_description_html || '';
   if (title) title.textContent = variant.title || '';
+  if (stickyTier) stickyTier.textContent = variant.tier || variant.title || '';
   // NEW: Rebuild bullet list from pre-split short description lines.
   if (shortDescription) {
     shortDescription.innerHTML = '';
@@ -94,6 +98,9 @@ function renderVariant(variant) {
   if (price) {
     const activePrice = variant.sale_price ?? variant.price;
     price.textContent = `$ ${Number(activePrice).toFixed(2)}`;
+    if (stickyPrice) {
+      stickyPrice.textContent = `$ ${Number(activePrice).toFixed(2)}`;
+    }
   }
 
   if (availability) {
@@ -113,6 +120,10 @@ function renderVariant(variant) {
     addToCartButton.dataset.gaCurrency = variant.currency || addToCartButton.dataset.gaCurrency || 'USD';
     addToCartButton.disabled = !variant.can_purchase;
     addToCartButton.textContent = variant.cart_cta_label || 'Out of Stock';
+    if (stickyButton) {
+      stickyButton.disabled = !variant.can_purchase;
+      stickyButton.textContent = variant.cart_cta_label || 'Out of Stock';
+    }
   }
 
   if (gallery) {
@@ -172,6 +183,8 @@ export function initSystemVariants() {
   const variantDataElement = document.getElementById('variant-data');
   const selector = document.getElementById('system-variant-selector');
   const addToCartButton = document.getElementById('spatc');
+  const stickyBar = document.getElementById('system-sticky-cart');
+  const stickyAddToCartButton = document.getElementById('system-sticky-addtocart');
 
   if (!variantDataElement || !selector || !addToCartButton) {
     return;
@@ -188,7 +201,8 @@ export function initSystemVariants() {
 
   const defaultVariantElement = document.getElementById('default-variant-id');
   const defaultVariantId = defaultVariantElement ? Number(JSON.parse(defaultVariantElement.textContent || '0')) : null;
-  selectedVariant = variants.find((variant) => variant.id === defaultVariantId) || variants[0];
+  const advancedVariant = variants.find((variant) => (variant.tier || '').toLowerCase() === 'advanced');
+  selectedVariant = advancedVariant || variants.find((variant) => variant.id === defaultVariantId) || variants[0];
 
   function syncActiveState() {
     selector.querySelectorAll('.system-variant-option').forEach((button) => {
@@ -217,6 +231,22 @@ export function initSystemVariants() {
     renderVariant(selectedVariant);
     syncActiveState();
   });
+
+  if (stickyBar && window.matchMedia('(max-width: 768px)').matches) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        stickyBar.classList.toggle('is-visible', !entry.isIntersecting);
+        stickyBar.setAttribute('aria-hidden', entry.isIntersecting ? 'true' : 'false');
+      });
+    }, { threshold: 0.25 });
+    observer.observe(addToCartButton);
+  }
+
+  if (stickyAddToCartButton) {
+    stickyAddToCartButton.addEventListener('click', () => {
+      addToCartButton.click();
+    });
+  }
 
   addToCartButton.addEventListener('click', async () => {
     if (addToCartButton.disabled) {


### PR DESCRIPTION
### Motivation
- Improve mobile conversion by surfacing the buying decision earlier on the Power Control System product page so paid ad traffic sees title, promise, image, tier selector, price, and Add to Cart above the fold. 
- Reduce mobile image dominance, make the `Advanced` tier selected/recommended by default, and ensure tier switching updates price, image, benefits, and the selected variant used for add-to-cart. 

### Description
- Updated the system variant branch of the product template (`shop/templates/shop/single_product.html`) to add a short promise under the title, a loop-driven tier selector with an `Advanced` Recommended badge, an in-context WhatsApp help CTA, and a new mobile sticky add-to-cart bar that mirrors selected tier and price. 
- Added targeted page-level SCSS (`shop/sass/pages/_single-product.scss`) to limit gallery height on mobile, tighten spacing, style compact tier cards and the sticky CTA, and avoid edits to `style.css`. 
- Enhanced the existing system variant feature module (`static/doobarashop/js/features/systemVariants.js`) to prefer an `Advanced` tier when present, keep the sticky bar tier/price/button in sync on variant switch, route sticky CTA clicks through the existing add-to-cart flow, and guard behavior to system-variant pages and mobile viewports. 
- Kept the implementation data-driven (no duplicated hard-coded Basic/Advanced/Pro blocks) and preserved existing analytics/add-to-cart behaviors and variant updates (price, image, package items, descriptions). 

### Testing
- Ran `python manage.py check` in the environment and it failed to initialize Django due to a missing environment variable (`SECRET_KEY`), so full Django checks could not be completed here. 
- No other automated project tests were executed in this environment; JavaScript changes were added without altering the existing add-to-cart API usage and include runtime guards so they only run on system variant pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f779dae35083249f7389f71d306039)