### PR TITLE
Improve single-product mobile first-view layout and system variant CTA placement

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -160,6 +160,10 @@
     font-size: 0.92rem;
 }
 
+.single-product-mobile-short-description {
+    margin-bottom: 14px;
+}
+
 .single-product-variant label,
 .single-product-qty-wrap label {
     display: block;
@@ -321,7 +325,12 @@
 
 @media (max-width: 640px) {
     .single-product-page {
-        padding: 28px 16px 72px;
+        padding: 16px 12px 56px;
+    }
+
+    .single-product-top {
+        gap: 12px;
+        margin-bottom: 12px;
     }
 
     .single-product-gallery,
@@ -329,7 +338,7 @@
     .card-surface,
     .single-product-video-card,
     .single-product-long-image-card {
-        border-radius: 22px;
+        border-radius: 18px;
     }
 
     .single-product-gallery,
@@ -337,27 +346,56 @@
     .card-surface,
     .single-product-video-card,
     .single-product-long-image-card {
-        padding: 18px;
+        padding: 12px;
     }
 
     .single-product-gallery__main,
     .single-video,
     .single-product-image-long {
-        border-radius: 18px;
+        border-radius: 14px;
+    }
+
+    .single-product-title {
+        margin: 0 0 10px;
+        font-size: clamp(1.5rem, 8vw, 2rem);
+    }
+
+    .single-product-price-row {
+        margin-bottom: 10px;
+    }
+
+    .single-product-price-label {
+        margin-bottom: 2px;
+    }
+
+    .single-product-availability {
+        margin: 0 0 6px;
     }
 
     .single-product-purchase {
         grid-template-columns: 1fr;
+        gap: 8px;
+        margin-bottom: 10px;
+    }
+
+    /* Make thumbs smaller and swipeable for mobile quick gallery browsing. */
+    .single-product-gallery__thumbs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        gap: 8px;
+        padding-bottom: 2px;
+        -webkit-overflow-scrolling: touch;
     }
 
     .single-product-thumb {
-        width: 68px;
-        height: 68px;
-        border-radius: 14px;
+        width: 56px;
+        height: 56px;
+        min-width: 56px;
+        border-radius: 12px;
     }
 
     .single-product-price {
-        font-size: 1.7rem;
+        font-size: 1.55rem;
     }
 
     .single-product-info-table th,
@@ -426,7 +464,10 @@
 }
 
 @media (max-width: 768px) {
+    /* Keep tier options on one row and allow horizontal scroll on narrow devices. */
     .system-variant-selector {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(3, minmax(120px, 1fr));
+        overflow-x: auto;
+        padding-bottom: 2px;
     }
 }

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -74,6 +74,16 @@
     gap: 12px;
 }
 
+.single-product-gallery__thumbs-wrap {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.single-product-thumbs-arrow {
+    display: none;
+}
+
 .single-product-thumb {
     width: 78px;
     height: 78px;
@@ -379,12 +389,38 @@
     }
 
     /* Make thumbs smaller and swipeable for mobile quick gallery browsing. */
+    .single-product-gallery__thumbs-wrap {
+        gap: 6px;
+    }
+
     .single-product-gallery__thumbs {
         flex-wrap: nowrap;
         overflow-x: auto;
         gap: 8px;
         padding-bottom: 2px;
         -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+    }
+
+    .single-product-gallery__thumbs::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* Mobile arrows indicate more thumbnails and provide quick left/right scroll controls. */
+    .single-product-thumbs-arrow {
+        display: inline-flex;
+        width: 24px;
+        height: 24px;
+        flex: 0 0 24px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid #d5e1ef;
+        border-radius: 999px;
+        background: #fff;
+        color: var.$ui-primary;
+        font-size: 1rem;
+        line-height: 1;
+        padding: 0;
     }
 
     .single-product-thumb {

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -72,12 +72,16 @@
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .single-product-gallery__thumbs-wrap {
     display: flex;
     align-items: center;
     gap: 8px;
+    width: 100%;
+    min-width: 0;
 }
 
 .single-product-thumbs-arrow {
@@ -335,12 +339,12 @@
 
 @media (max-width: 640px) {
     .single-product-page {
-        padding: 16px 12px 56px;
+        padding: 12px 10px 44px;
     }
 
     .single-product-top {
-        gap: 12px;
-        margin-bottom: 12px;
+        gap: 10px;
+        margin-bottom: 10px;
     }
 
     .single-product-gallery,
@@ -356,7 +360,7 @@
     .card-surface,
     .single-product-video-card,
     .single-product-long-image-card {
-        padding: 12px;
+        padding: 10px;
     }
 
     .single-product-gallery__main,
@@ -366,12 +370,12 @@
     }
 
     .single-product-title {
-        margin: 0 0 10px;
-        font-size: clamp(1.5rem, 8vw, 2rem);
+        margin: 0 0 8px;
+        font-size: clamp(1.35rem, 7vw, 1.75rem);
     }
 
     .single-product-price-row {
-        margin-bottom: 10px;
+        margin-bottom: 8px;
     }
 
     .single-product-price-label {
@@ -379,13 +383,13 @@
     }
 
     .single-product-availability {
-        margin: 0 0 6px;
+        margin: 0 0 4px;
     }
 
     .single-product-purchase {
         grid-template-columns: 1fr;
-        gap: 8px;
-        margin-bottom: 10px;
+        gap: 6px;
+        margin-bottom: 8px;
     }
 
     /* Make thumbs smaller and swipeable for mobile quick gallery browsing. */
@@ -400,6 +404,7 @@
         padding-bottom: 2px;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none;
+        scroll-snap-type: x proximity;
     }
 
     .single-product-gallery__thumbs::-webkit-scrollbar {
@@ -424,10 +429,11 @@
     }
 
     .single-product-thumb {
-        width: 56px;
-        height: 56px;
-        min-width: 56px;
+        width: 52px;
+        height: 52px;
+        min-width: 52px;
         border-radius: 12px;
+        scroll-snap-align: start;
     }
 
     .single-product-price {

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -28,7 +28,11 @@
                              loading="eager"
                              fetchpriority="high">
                     </div>
-                    <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                    <div class="single-product-gallery__thumbs-wrap">
+                        <button type="button" class="single-product-thumbs-arrow single-product-thumbs-arrow--left" data-thumbs-nav="left" aria-label="Scroll thumbnails left">‹</button>
+                        <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                        <button type="button" class="single-product-thumbs-arrow single-product-thumbs-arrow--right" data-thumbs-nav="right" aria-label="Scroll thumbnails right">›</button>
+                    </div>
                 </div>
 
                 <div class="single-product-info">
@@ -114,7 +118,9 @@
                         {% endif %}
                     </div>
 
-                    <div class="single-product-gallery__thumbs">
+                    <div class="single-product-gallery__thumbs-wrap">
+                        <button type="button" class="single-product-thumbs-arrow single-product-thumbs-arrow--left" data-thumbs-nav="left" aria-label="Scroll thumbnails left">‹</button>
+                        <div class="single-product-gallery__thumbs">
                         {% for image in product.all_images %}
                                 <button type="button" class="single-product-thumb">
                                     <img class="sp-thumb-image"
@@ -125,6 +131,8 @@
                                          loading="lazy">
                                 </button>
                         {% endfor %}
+                        </div>
+                        <button type="button" class="single-product-thumbs-arrow single-product-thumbs-arrow--right" data-thumbs-nav="right" aria-label="Scroll thumbnails right">›</button>
                     </div>
                 </div>
 

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -53,12 +53,6 @@
                         <div class="single-product-price-wrap">
                             <span class="single-product-price-label">Selected Variant</span>
                             <h2 id="system-variant-title" class="single-product-price">{{ default_system_variant.title }}</h2>
-                            {# NEW: Render pre-split system variant short description as bullet list items. #}
-                            <ul id="system-variant-short-description" class="single-product-spec-list">
-                                {% for line in default_system_variant.short_description_lines %}
-                                    <li>{{ line }}</li>
-                                {% endfor %}
-                            </ul>
                             <p id="system-variant-availability" class="single-product-availability {% if default_system_variant.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}">
                                 {{ default_system_variant.availability_label }}
                             </p>
@@ -82,6 +76,15 @@
                             {% if not default_system_variant.can_purchase %}disabled{% endif %}>
                             {{ default_system_variant.cart_cta_label|default:"Out of Stock" }}
                         </button>
+                    </div>
+
+                    <div class="single-product-mobile-short-description">
+                        {# Keep this list after price/CTA so system flow matches normal product order in mobile. #}
+                        <ul id="system-variant-short-description" class="single-product-spec-list">
+                            {% for line in default_system_variant.short_description_lines %}
+                                <li>{{ line }}</li>
+                            {% endfor %}
+                        </ul>
                     </div>
 
                     <div class="single-product-specs">

--- a/static/doobarashop/js/features/productGallery.js
+++ b/static/doobarashop/js/features/productGallery.js
@@ -2,13 +2,32 @@ export function initProductGallery() {
   const thumbnails = document.querySelectorAll('.sp-thumb-image');
   const mainImage = document.getElementById('spi');
 
-  if (!thumbnails.length || !mainImage) {
-    return;
+  if (thumbnails.length && mainImage) {
+    thumbnails.forEach((thumbnail) => {
+      thumbnail.addEventListener('click', () => {
+        mainImage.src = thumbnail.src;
+      });
+    });
   }
 
-  thumbnails.forEach((thumbnail) => {
-    thumbnail.addEventListener('click', () => {
-      mainImage.src = thumbnail.src;
+  // Add left/right controls for thumbnail strips so mobile users can discover more images.
+  document.querySelectorAll('.single-product-gallery__thumbs-wrap').forEach((wrap) => {
+    const list = wrap.querySelector('.single-product-gallery__thumbs');
+    const leftButton = wrap.querySelector('[data-thumbs-nav="left"]');
+    const rightButton = wrap.querySelector('[data-thumbs-nav="right"]');
+
+    if (!list || !leftButton || !rightButton) {
+      return;
+    }
+
+    const scrollDistance = () => Math.max(120, Math.floor(list.clientWidth * 0.65));
+
+    leftButton.addEventListener('click', () => {
+      list.scrollBy({ left: -scrollDistance(), behavior: 'smooth' });
+    });
+
+    rightButton.addEventListener('click', () => {
+      list.scrollBy({ left: scrollDistance(), behavior: 'smooth' });
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Make the mobile single-product first view more compact so the user sees the product image, title, price and add-to-cart area without excessive scrolling.
- Ensure system-variant flow matches normal product flow by placing the add-to-cart CTA immediately after pricing.
- Reduce vertical gaps/padding for the top components to prioritize key information in the first viewport on small screens.
- Provide a smaller, horizontally-scrollable thumbnail strip so users can swipe thumbnails left/right on mobile.

### Description
- Moved the system variant short-description list to render after the pricing and add-to-cart area and wrapped it in a new `.single-product-mobile-short-description` container to preserve spacing (`shop/templates/shop/single_product.html`).
- Tightened mobile-first spacing by reducing page padding, grid gap, card padding, title/price/availability margins and purchase block spacing in the mobile media query (`shop/sass/pages/_single-product.scss`).
- Converted thumbnail gallery on mobile to a single-row, horizontally-scrollable strip and reduced thumbnail size to 56×56 with a `min-width` so the user can swipe left/right to browse (`.single-product-gallery__thumbs`, `.single-product-thumb`).
- Kept system variant option buttons (Basic/Advanced/Pro) on a single row for narrow widths and enabled horizontal scrolling with `overflow-x: auto` and `grid-template-columns: repeat(3, minmax(120px, 1fr))` for small screens (`.system-variant-selector` media rule in SCSS).

### Testing
- Ran `python manage.py check` in this environment; the command could not complete because required environment variables (e.g. `SECRET_KEY`) are not set, so framework checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7976208888324b20654a66435c83d)