### PR TITLE
Mobile-first refactor: surface system tier selector, price and sticky Add‑to‑Cart on product pages

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -70,8 +70,32 @@
 
 .single-product-gallery__thumbs {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 12px;
+    overflow-x: auto;
+    scroll-behavior: smooth;
+    scrollbar-width: thin;
+}
+
+.single-product-gallery__thumb-carousel {
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr) 34px;
+    align-items: center;
+    gap: 8px;
+}
+
+.single-product-gallery__thumb-arrow {
+    border: 1px solid #d7e4f4;
+    background: #fff;
+    border-radius: 999px;
+    height: 32px;
+    width: 32px;
+    font-size: 1.1rem;
+}
+
+.single-product-gallery__thumb-arrow.is-hidden,
+.single-product-gallery__thumb-arrow:disabled {
+    opacity: 0.4;
 }
 
 .single-product-thumb {
@@ -114,6 +138,26 @@
     font-size: clamp(2rem, 4vw, 3rem);
     line-height: 1.08;
     color: var.$ui-dark;
+}
+
+.single-product-system-promise {
+    margin: 0 0 12px;
+    color: var.$ui-text-soft;
+}
+
+.system-variant-option__badge {
+    display: inline-block;
+    padding: 2px 8px;
+    margin-top: 6px;
+    border-radius: 999px;
+    background: rgba(21, 112, 239, 0.1);
+    color: var.$ui-primary;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.single-product-mobile-sticky-bar {
+    display: none;
 }
 
 .single-product-price-row {
@@ -277,6 +321,87 @@
     grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
     gap: 24px;
     align-items: start;
+}
+
+@media (max-width: 980px) {
+    .single-product-page {
+        padding-top: 26px;
+        padding-bottom: 110px;
+    }
+
+    .single-product-top {
+        grid-template-columns: 1fr;
+        gap: 14px;
+    }
+
+    .single-product-gallery {
+        padding-top: 12px;
+        padding-bottom: 12px;
+    }
+
+    .single-product-gallery__main {
+        max-height: 250px;
+        margin-bottom: 10px;
+    }
+
+    .single-product-info {
+        position: static;
+        padding-top: 16px;
+        padding-bottom: 16px;
+    }
+
+    .single-product-title {
+        margin-bottom: 10px;
+        font-size: clamp(1.5rem, 6vw, 2rem);
+    }
+
+    .single-product-price-row,
+    .system-variant-selector,
+    .single-product-purchase {
+        margin-bottom: 12px;
+    }
+
+    .single-product-purchase {
+        grid-template-columns: 1fr;
+    }
+
+    .single-product-gallery__thumbs {
+        padding-top: 2px;
+        padding-bottom: 2px;
+    }
+
+    .single-product-mobile-sticky-bar {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 10px 16px calc(10px + env(safe-area-inset-bottom));
+        background: rgba(255, 255, 255, 0.98);
+        border-top: 1px solid #e2e8f0;
+        box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.12);
+        transform: translateY(100%);
+        transition: transform 0.22s ease;
+        z-index: 40;
+    }
+
+    .single-product-mobile-sticky-bar.is-visible {
+        transform: translateY(0);
+    }
+
+    .single-product-mobile-sticky-bar__meta {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .single-product-mobile-sticky-bar__button {
+        @include var.action-button-base(44px, 0 14px, 12px);
+        @include var.action-button-dark(var.$ui-dark, #10233f, none);
+        font-size: 0.9rem;
+    }
 }
 
 .single-product-info-table {

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -28,12 +28,19 @@
                              loading="eager"
                              fetchpriority="high">
                     </div>
-                    <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                    <div class="single-product-gallery__thumb-carousel">
+                        <button type="button" class="single-product-gallery__thumb-arrow is-left" data-gallery-scroll="left" aria-label="Scroll thumbnails left">‹</button>
+                        <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                        <button type="button" class="single-product-gallery__thumb-arrow is-right" data-gallery-scroll="right" aria-label="Scroll thumbnails right">›</button>
+                    </div>
                 </div>
 
                 <div class="single-product-info">
                     <span class="single-product-info__eyebrow">Doobara System</span>
                     <h1 class="single-product-title">{{ product.title }}</h1>
+                    {% if default_system_variant.short_description_lines %}
+                        <p class="single-product-system-promise">{{ default_system_variant.short_description_lines.0 }}</p>
+                    {% endif %}
 
                     <div class="system-variant-selector" id="system-variant-selector">
                         {% for variant in system_variants %}
@@ -42,6 +49,9 @@
                                 class="system-variant-option {% if default_system_variant.id == variant.id %}is-active{% endif %}"
                                 data-variant-id="{{ variant.id }}">
                                 <span class="system-variant-option__tier">{{ variant.tier|title }}</span>
+                                {% if variant.is_recommended %}
+                                    <span class="system-variant-option__badge">Recommended</span>
+                                {% endif %}
                                 <span class="system-variant-option__price">
                                     $ {% if variant.sale_price %}{{ variant.sale_price|floatformat:2 }}{% else %}{{ variant.price|floatformat:2 }}{% endif %}
                                 </span>
@@ -82,6 +92,14 @@
                             {% if not default_system_variant.can_purchase %}disabled{% endif %}>
                             {{ default_system_variant.cart_cta_label|default:"Out of Stock" }}
                         </button>
+                    </div>
+
+                    <div id="system-mobile-sticky-bar" class="single-product-mobile-sticky-bar" aria-hidden="true">
+                        <div class="single-product-mobile-sticky-bar__meta">
+                            <strong id="system-mobile-sticky-tier">{{ default_system_variant.tier|title }}</strong>
+                            <span id="system-mobile-sticky-price">$ {% if default_system_variant.sale_price %}{{ default_system_variant.sale_price|floatformat:2 }}{% else %}{{ default_system_variant.price|floatformat:2 }}{% endif %}</span>
+                        </div>
+                        <button type="button" id="system-mobile-sticky-atc" class="single-product-mobile-sticky-bar__button">{{ default_system_variant.cart_cta_label|default:"Out of Stock" }}</button>
                     </div>
 
                     <div class="single-product-specs">

--- a/shop/views.py
+++ b/shop/views.py
@@ -255,6 +255,9 @@ def single_product(request, locat=None, slug=None):
             "images": images,
             "package_items": package_items,
             "is_default": variant.is_default,
+            # Optional admin/model flag support: if present in data model later,
+            # frontend can highlight the recommended tier without template rewrites.
+            "is_recommended": bool(getattr(variant, "is_recommended", False)),
             "sort_order": variant.sort_order,
         }
         system_variants.append(variant_payload)

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -78,6 +78,9 @@ function renderVariant(variant) {
   const packageItems = document.getElementById('system-variant-package-items');
   const addToCartButton = document.getElementById('spatc');
   const specifications = document.getElementById('longdescription');
+  const stickyTier = document.getElementById('system-mobile-sticky-tier');
+  const stickyPrice = document.getElementById('system-mobile-sticky-price');
+  const stickyAtc = document.getElementById('system-mobile-sticky-atc');
 
   // NEW: System variant long description is pre-rendered HTML from server-side markdown conversion.
   if (specifications) specifications.innerHTML = variant.long_description_html || '';
@@ -113,6 +116,20 @@ function renderVariant(variant) {
     addToCartButton.dataset.gaCurrency = variant.currency || addToCartButton.dataset.gaCurrency || 'USD';
     addToCartButton.disabled = !variant.can_purchase;
     addToCartButton.textContent = variant.cart_cta_label || 'Out of Stock';
+  }
+
+  if (stickyTier) {
+    stickyTier.textContent = variant.tier
+      ? variant.tier.charAt(0).toUpperCase() + variant.tier.slice(1)
+      : (variant.title || 'Selected Tier');
+  }
+  if (stickyPrice) {
+    const activePrice = variant.sale_price ?? variant.price;
+    stickyPrice.textContent = `$ ${Number(activePrice).toFixed(2)}`;
+  }
+  if (stickyAtc) {
+    stickyAtc.disabled = !variant.can_purchase;
+    stickyAtc.textContent = variant.cart_cta_label || 'Out of Stock';
   }
 
   if (gallery) {
@@ -172,6 +189,9 @@ export function initSystemVariants() {
   const variantDataElement = document.getElementById('variant-data');
   const selector = document.getElementById('system-variant-selector');
   const addToCartButton = document.getElementById('spatc');
+  const stickyBar = document.getElementById('system-mobile-sticky-bar');
+  const stickyAtc = document.getElementById('system-mobile-sticky-atc');
+  const gallery = document.getElementById('system-variant-gallery');
 
   if (!variantDataElement || !selector || !addToCartButton) {
     return;
@@ -197,8 +217,23 @@ export function initSystemVariants() {
     });
   }
 
+  function syncGalleryArrows() {
+    // Keep arrow affordances accurate so users can discover hidden thumbnails on mobile.
+    if (!gallery) return;
+    const leftArrow = document.querySelector('[data-gallery-scroll="left"]');
+    const rightArrow = document.querySelector('[data-gallery-scroll="right"]');
+    if (!leftArrow || !rightArrow) return;
+
+    const canScroll = gallery.scrollWidth > gallery.clientWidth + 2;
+    leftArrow.disabled = !canScroll || gallery.scrollLeft <= 0;
+    rightArrow.disabled = !canScroll || (gallery.scrollLeft + gallery.clientWidth >= gallery.scrollWidth - 1);
+    leftArrow.classList.toggle('is-hidden', !canScroll);
+    rightArrow.classList.toggle('is-hidden', !canScroll);
+  }
+
   renderVariant(selectedVariant);
   syncActiveState();
+  syncGalleryArrows();
 
   selector.addEventListener('click', (event) => {
     const targetButton = event.target.closest('.system-variant-option');
@@ -216,6 +251,38 @@ export function initSystemVariants() {
     selectedVariant = found;
     renderVariant(selectedVariant);
     syncActiveState();
+    syncGalleryArrows();
+  });
+
+  gallery?.addEventListener('scroll', syncGalleryArrows, { passive: true });
+  window.addEventListener('resize', syncGalleryArrows);
+
+  document.querySelector('[data-gallery-scroll="left"]')?.addEventListener('click', () => {
+    gallery?.scrollBy({ left: -180, behavior: 'smooth' });
+  });
+
+  document.querySelector('[data-gallery-scroll="right"]')?.addEventListener('click', () => {
+    gallery?.scrollBy({ left: 180, behavior: 'smooth' });
+  });
+
+  if (stickyBar) {
+    const purchaseBlock = document.querySelector('.single-product-purchase');
+    const mobileQuery = window.matchMedia('(max-width: 980px)');
+    // Show sticky add-to-cart only after primary CTA scrolls out of view on mobile.
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      const showBar = mobileQuery.matches && !entry.isIntersecting;
+      stickyBar.classList.toggle('is-visible', showBar);
+      stickyBar.setAttribute('aria-hidden', showBar ? 'false' : 'true');
+    }, { threshold: 0.15 });
+
+    if (purchaseBlock) {
+      observer.observe(purchaseBlock);
+    }
+  }
+
+  stickyAtc?.addEventListener('click', () => {
+    addToCartButton.click();
   });
 
   addToCartButton.addEventListener('click', async () => {


### PR DESCRIPTION
### Motivation
- Reduce vertical friction on mobile system product detail pages so the buying decision (title, short promise, image, tier selector, price, and Add to Cart) appears much earlier in the first viewport. 
- Keep desktop behavior and non-system product templates unchanged while applying changes only to the system product branch. 
- Ensure tier switching remains authoritative (selected ProductVariant is used for Add to Cart and analytics) and make thumbnail row behave as a horizontal carousel on overflow. 

### Description
- Template: updated `shop/templates/shop/single_product.html` to add an early short promise under the title, a thumbnail carousel wrapper with left/right arrow buttons, an optional `Recommended` badge for variants, and a mobile sticky Add‑to‑Cart bar that mirrors the selected tier and price. 
- View: extended system variant payload in `shop/views.py` to include a safe optional `is_recommended` key so the frontend can highlight recommended tiers without breaking existing data. 
- Frontend JS: enhanced `static/doobarashop/js/features/systemVariants.js` to keep the selected tier, price, main image, package items, hidden variant id, and GA4/Meta metadata in sync, to drive thumbnail arrow visibility and smooth horizontal scrolling, and to show/hide the sticky mobile bar via an `IntersectionObserver` (DOM-guarded so it only runs on system pages). 
- Styles: added scoped SCSS in `shop/sass/pages/_single-product.scss` (no edits to `style.css`) to: cap mobile gallery height, tighten vertical spacing, make thumbnail row overflow horizontally instead of shrinking, style carousel arrows, and implement the sticky bottom ATC bar while preserving horizontal padding and touch targets. 
- Assumptions: there is no guaranteed `is_recommended` model field today so the backend exposes a boolean fallback (`getattr(..., False)`), and the existing `/shopaddtocart` variant API remains the Add‑to‑cart path for system variants. 

### Testing
- Attempted to run `python manage.py check` but the command failed in this environment due to a missing `SECRET_KEY` environment variable, so Django system checks could not complete (no automated test failures from code itself were observed in this container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aaa33c348324870d941a57c32e00)