### PR TITLE
Single-product: mobile layout tweaks, horizontal thumbnails, and variant CTA alignment

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -321,7 +321,12 @@
 
 @media (max-width: 640px) {
     .single-product-page {
-        padding: 28px 16px 72px;
+        padding: 18px 16px 64px;
+    }
+
+    .single-product-top {
+        gap: 14px;
+        margin-bottom: 14px;
     }
 
     .single-product-gallery,
@@ -337,7 +342,7 @@
     .card-surface,
     .single-product-video-card,
     .single-product-long-image-card {
-        padding: 18px;
+        padding: 14px 18px;
     }
 
     .single-product-gallery__main,
@@ -348,12 +353,39 @@
 
     .single-product-purchase {
         grid-template-columns: 1fr;
+        margin-bottom: 12px;
     }
 
     .single-product-thumb {
-        width: 68px;
-        height: 68px;
-        border-radius: 14px;
+        width: 58px;
+        height: 58px;
+        border-radius: 12px;
+    }
+
+    .single-product-gallery__thumbs {
+        /* Make mobile thumbnails swipeable horizontally while hiding overflowed items. */
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        padding-bottom: 2px;
+    }
+
+    .single-product-gallery__thumbs::-webkit-scrollbar {
+        display: none;
+    }
+
+    .single-product-title {
+        margin-bottom: 10px;
+    }
+
+    .single-product-price-row {
+        margin-bottom: 10px;
+    }
+
+    .system-variant-selector {
+        margin: 10px 0;
     }
 
     .single-product-price {
@@ -427,6 +459,15 @@
 
 @media (max-width: 768px) {
     .system-variant-selector {
-        grid-template-columns: 1fr;
+        /* Keep all tier options in one mobile row with horizontal scrolling when needed. */
+        grid-template-columns: repeat(3, minmax(108px, 1fr));
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding-bottom: 2px;
+        scrollbar-width: none;
+    }
+
+    .system-variant-selector::-webkit-scrollbar {
+        display: none;
     }
 }

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -102,6 +102,7 @@
     padding: 28px;
     position: sticky;
     top: 110px;
+    min-width: 0;
 }
 
 .single-product-info__eyebrow {
@@ -466,16 +467,26 @@
 }
 
 @media (max-width: 768px) {
+    .single-product-page--system {
+        /* Prevent horizontal page drag on system-variant mobile view from wide internal rails. */
+        overflow-x: clip;
+    }
+
     .system-variant-selector {
-        /* Keep all tier options in one mobile row with horizontal scrolling when needed. */
+        /* Use a single-row horizontal rail to avoid grid min-content width stretching. */
+        display: flex;
+        flex-wrap: nowrap;
         width: 100%;
         max-width: 100%;
-        grid-template-columns: repeat(3, minmax(108px, 1fr));
         overflow-x: auto;
         overflow-y: hidden;
         overscroll-behavior-x: contain;
         padding-bottom: 2px;
         scrollbar-width: none;
+    }
+
+    .system-variant-option {
+        flex: 0 0 108px;
     }
 
     .system-variant-selector::-webkit-scrollbar {

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -473,23 +473,18 @@
     }
 
     .system-variant-selector {
-        /* Use a single-row horizontal rail to avoid grid min-content width stretching. */
-        display: flex;
-        flex-wrap: nowrap;
+        /* Keep Basic/Advanced/Pro fitting in one mobile row without horizontal sliding. */
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         width: 100%;
         max-width: 100%;
-        overflow-x: auto;
-        overflow-y: hidden;
-        overscroll-behavior-x: contain;
-        padding-bottom: 2px;
-        scrollbar-width: none;
+        overflow: hidden;
+        gap: 8px;
     }
 
     .system-variant-option {
-        flex: 0 0 108px;
-    }
-
-    .system-variant-selector::-webkit-scrollbar {
-        display: none;
+        min-width: 0;
+        width: 100%;
+        padding: 10px 8px;
     }
 }

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -345,6 +345,10 @@
         padding: 14px 18px;
     }
 
+    .single-product-gallery {
+        overflow: hidden;
+    }
+
     .single-product-gallery__main,
     .single-video,
     .single-product-image-long {
@@ -357,6 +361,7 @@
     }
 
     .single-product-thumb {
+        flex: 0 0 58px;
         width: 58px;
         height: 58px;
         border-radius: 12px;
@@ -364,9 +369,12 @@
 
     .single-product-gallery__thumbs {
         /* Make mobile thumbnails swipeable horizontally while hiding overflowed items. */
+        width: 100%;
+        max-width: 100%;
         flex-wrap: nowrap;
         overflow-x: auto;
         overflow-y: hidden;
+        overscroll-behavior-x: contain;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none;
         padding-bottom: 2px;
@@ -460,9 +468,12 @@
 @media (max-width: 768px) {
     .system-variant-selector {
         /* Keep all tier options in one mobile row with horizontal scrolling when needed. */
+        width: 100%;
+        max-width: 100%;
         grid-template-columns: repeat(3, minmax(108px, 1fr));
         overflow-x: auto;
         overflow-y: hidden;
+        overscroll-behavior-x: contain;
         padding-bottom: 2px;
         scrollbar-width: none;
     }

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -53,12 +53,6 @@
                         <div class="single-product-price-wrap">
                             <span class="single-product-price-label">Selected Variant</span>
                             <h2 id="system-variant-title" class="single-product-price">{{ default_system_variant.title }}</h2>
-                            {# NEW: Render pre-split system variant short description as bullet list items. #}
-                            <ul id="system-variant-short-description" class="single-product-spec-list">
-                                {% for line in default_system_variant.short_description_lines %}
-                                    <li>{{ line }}</li>
-                                {% endfor %}
-                            </ul>
                             <p id="system-variant-availability" class="single-product-availability {% if default_system_variant.can_purchase %}is-in-stock{% else %}is-out-of-stock{% endif %}">
                                 {{ default_system_variant.availability_label }}
                             </p>
@@ -83,6 +77,12 @@
                             {{ default_system_variant.cart_cta_label|default:"Out of Stock" }}
                         </button>
                     </div>
+                    {# Keep system variant CTA aligned with normal product flow: price -> CTA -> short description. #}
+                    <ul id="system-variant-short-description" class="single-product-spec-list">
+                        {% for line in default_system_variant.short_description_lines %}
+                            <li>{{ line }}</li>
+                        {% endfor %}
+                    </ul>
 
                     <div class="single-product-specs">
                         <h3>Included items</h3>

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -14,7 +14,7 @@
 {% block twitter_image %}{% if social_image %}{{ social_image }}{% else %}{{ request.scheme }}://{{ request.get_host }}{% static 'doobarashop/upload/images/logo-creation.png' %}{% endif %}{% endblock %}
 
 {% block body %}
-<section class="single-product-page">
+<section class="single-product-page {% if product.system %}single-product-page--system{% endif %}">
     <div class="single-product-shell">
         {% if product.system and system_variants %}
             <div class="single-product-top">


### PR DESCRIPTION
### Motivation
- Improve the mobile first-view so the product image, title, price, and add-to-cart CTA appear together and reduce vertical whitespace for a tighter first-fold experience.
- Align system-variant interaction flow with normal products by placing the system variant `add to cart` CTA after pricing and before the short description.
- Make thumbnail selection more mobile-friendly by shrinking thumbs and enabling horizontal swipe/scroll so off-screen thumbs are hidden until the user scrolls.
- Keep system variant tier options (Basic/Advanced/Pro) visible on a single row on mobile with horizontal scrolling when needed.

### Description
- Moved the system-variant short description below the purchase CTA in `shop/templates/shop/single_product.html` so the CTA is located directly after the price (price -> CTA -> short description).
- Reduced vertical spacing on mobile by updating mobile padding and the `.single-product-top` gap in `shop/sass/pages/_single-product.scss` to minimize top/bottom gaps for the first view.
- Reduced thumbnail size on mobile and made the thumbnail list horizontally scrollable by changing `.single-product-thumb` sizing and adding horizontal overflow rules to `.single-product-gallery__thumbs` in `shop/sass/pages/_single-product.scss` so the thumbnails behave like a swipeable carousel.
- Kept system variant options in a single mobile row by modifying `.system-variant-selector` grid rules and enabling horizontal scroll/hidden overflow for mobile in `shop/sass/pages/_single-product.scss`.
- Files changed: `shop/templates/shop/single_product.html`, `shop/sass/pages/_single-product.scss`.

### Testing
- No automated tests were run for this change; changes were validated by reviewing the template and SCSS diffs and committing the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b3e9564c8324a492355d5ee287a7)