### PR TITLE
Fix checkout error form initialization for cart-empty flow

### DIFF
--- a/users/modules/ordermanager.py
+++ b/users/modules/ordermanager.py
@@ -15,7 +15,9 @@ from promotions.services import (
 
 def _build_checkout_error_form(message):
     # Centralize non-field checkout errors so caller can re-render checkout safely.
-    form = Delivery_Information()
+    # Call full_clean() first so cleaned_data exists before add_error() mutates form state.
+    form = Delivery_Information(data={})
+    form.full_clean()
     form.add_error(None, message)
     return form
 


### PR DESCRIPTION
### Motivation
- Fix the Sentry-reported `AttributeError` in `/placeorder` where `Delivery_Information` had no `cleaned_data` when a non-field checkout error (e.g., empty cart) was returned.

### Description
- Update `_build_checkout_error_form` to instantiate `Delivery_Information` as a bound form (`Delivery_Information(data={})`) and call `full_clean()` before `add_error(...)` so `cleaned_data` is present.

### Testing
- Ran `python -m compileall users/modules/ordermanager.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d474de5883248604573f269e9680)