### PR TITLE
Compact mobile product/system landing layout and WhatsApp CTA improvements

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -357,6 +357,13 @@
 
     .single-product-gallery {
         overflow: hidden;
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+
+    .single-product-gallery__main {
+        aspect-ratio: 1.18 / 1;
+        margin-bottom: 8px;
     }
 
     .single-product-gallery__main,
@@ -377,22 +384,7 @@
         border-radius: 12px;
     }
 
-    .single-product-gallery__thumbs {
-        /* Make mobile thumbnails swipeable horizontally while hiding overflowed items. */
-        width: 100%;
-        max-width: 100%;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        overflow-y: hidden;
-        overscroll-behavior-x: contain;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-        padding-bottom: 2px;
-    }
-
-    .single-product-gallery__thumbs::-webkit-scrollbar {
-        display: none;
-    }
+    .single-product-gallery__thumbs { display: none; }
 
     .single-product-title {
         margin-bottom: 10px;
@@ -497,3 +489,39 @@
         padding: 10px 8px;
     }
 }
+
+
+.single-product-gallery__dots {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.single-product-gallery__dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    border: 0;
+    background: #d1d5db;
+}
+
+.single-product-gallery__dot.is-active { background: var.$ui-primary; }
+
+.single-product-whatsapp-help {
+    display: block;
+    margin-top: 10px;
+    text-align: center;
+    border: 1px solid #25D366;
+    color: #1f9b4d;
+    border-radius: 12px;
+    padding: 11px 12px;
+    font-weight: 700;
+}
+
+.single-product-hero-description {
+    margin: 0 0 10px;
+    color: var.$ui-text-soft;
+}
+
+.single-product-spec-list--hero { margin: 0 0 12px; }

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -29,11 +29,17 @@
                              fetchpriority="high">
                     </div>
                     <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                    <div id="system-variant-gallery-dots" class="single-product-gallery__dots" aria-label="Image pagination"></div>
                 </div>
 
                 <div class="single-product-info">
                     <span class="single-product-info__eyebrow">Doobara System</span>
                     <h1 class="single-product-title">{{ product.title }}</h1>
+                    <ul id="system-variant-short-description" class="single-product-spec-list single-product-spec-list--hero">
+                        {% for line in default_system_variant.short_description_lines %}
+                            <li>{{ line }}</li>
+                        {% endfor %}
+                    </ul>
 
                     <div class="system-variant-selector" id="system-variant-selector">
                         {% for variant in system_variants %}
@@ -76,13 +82,14 @@
                             {% if not default_system_variant.can_purchase %}disabled{% endif %}>
                             {{ default_system_variant.cart_cta_label|default:"Out of Stock" }}
                         </button>
+                        <a href="https://wa.me/96170856471"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="single-product-whatsapp-help"
+                           data-whatsapp-help-link>
+                            Not sure which tier fits your setup? Ask us on WhatsApp
+                        </a>
                     </div>
-                    {# Keep system variant CTA aligned with normal product flow: price -> CTA -> short description. #}
-                    <ul id="system-variant-short-description" class="single-product-spec-list">
-                        {% for line in default_system_variant.short_description_lines %}
-                            <li>{{ line }}</li>
-                        {% endfor %}
-                    </ul>
 
                     <div class="single-product-specs">
                         <h3>Included items</h3>
@@ -123,12 +130,16 @@
                                 </button>
                         {% endfor %}
                     </div>
+                    <div class="single-product-gallery__dots" id="normal-gallery-dots" aria-label="Image pagination"></div>
                 </div>
 
                 <!-- Right: content / buy box -->
                 <div class="single-product-info">
                     <span class="single-product-info__eyebrow">Doobara Product</span>
                     <h1 class="single-product-title">{{ product.title }}</h1>
+                    {% if product.pshortdescription and product.pshortdescription.0 %}
+                        <p class="single-product-hero-description">{{ product.pshortdescription.0 }}</p>
+                    {% endif %}
 
                     <div class="single-product-price-row">
                         <div class="single-product-price-wrap">
@@ -182,6 +193,13 @@
                                 {% if not product.can_purchase %}disabled{% endif %}>
                             {{ product.cart_cta_label|default:"Out of Stock" }}
                         </button>
+                        <a href="https://wa.me/96170856471"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="single-product-whatsapp-help"
+                           data-whatsapp-help-link>
+                            Not sure which tier fits your setup? Ask us on WhatsApp
+                        </a>
                     </div>
 
                     <div class="single-product-trust">

--- a/static/doobarashop/js/features/footerAndWhatsapp.js
+++ b/static/doobarashop/js/features/footerAndWhatsapp.js
@@ -4,18 +4,21 @@ export function initFooterAndWhatsapp() {
     yearElement.textContent = String(new Date().getFullYear());
   }
 
-  const whatsappHeaderLink = document.getElementById('whatsapp-header-link');
-  if (!whatsappHeaderLink) {
-    return;
-  }
-
   const pageTitle = document.title ? document.title.trim() : '';
+  const pageUrl = window.location.href;
   if (!pageTitle) {
     return;
   }
 
-  // Build a page-aware prefilled message so support can instantly see where the user came from.
-  const message = `Hi Doobara, I'm visiting: ${pageTitle}`;
+  // Reuse one shared WhatsApp prefilled message across header and product CTA links.
+  const message = `Hi Doobara, I'm visiting: ${pageTitle} (${pageUrl})`;
   const encodedMessage = encodeURIComponent(message);
-  whatsappHeaderLink.href = `${whatsappHeaderLink.href}?text=${encodedMessage}`;
+
+  document.querySelectorAll('#whatsapp-header-link, [data-whatsapp-help-link]').forEach((link) => {
+    if (!(link instanceof HTMLAnchorElement)) {
+      return;
+    }
+    const baseHref = link.href.split('?')[0];
+    link.href = `${baseHref}?text=${encodedMessage}`;
+  });
 }

--- a/static/doobarashop/js/features/productGallery.js
+++ b/static/doobarashop/js/features/productGallery.js
@@ -1,14 +1,56 @@
 export function initProductGallery() {
-  const thumbnails = document.querySelectorAll('.sp-thumb-image');
+  const thumbnails = Array.from(document.querySelectorAll('.sp-thumb-image'));
   const mainImage = document.getElementById('spi');
+  const mainMedia = document.querySelector('.single-product-gallery__main');
+  const dotsContainer = document.getElementById('normal-gallery-dots');
 
-  if (!thumbnails.length || !mainImage) {
+  if (!thumbnails.length || !mainImage || !mainMedia) {
     return;
   }
 
-  thumbnails.forEach((thumbnail) => {
-    thumbnail.addEventListener('click', () => {
-      mainImage.src = thumbnail.src;
-    });
+  let currentIndex = 0;
+
+  function setActiveImage(index) {
+    const boundedIndex = (index + thumbnails.length) % thumbnails.length;
+    currentIndex = boundedIndex;
+    const activeThumb = thumbnails[boundedIndex];
+    mainImage.src = activeThumb.src;
+    mainImage.alt = activeThumb.alt || mainImage.alt;
+
+    if (dotsContainer) {
+      dotsContainer.querySelectorAll('button').forEach((dot, dotIndex) => {
+        dot.classList.toggle('is-active', dotIndex === boundedIndex);
+      });
+    }
+  }
+
+  thumbnails.forEach((thumbnail, index) => {
+    thumbnail.addEventListener('click', () => setActiveImage(index));
   });
+
+  if (dotsContainer && thumbnails.length > 1) {
+    thumbnails.forEach((_, index) => {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'single-product-gallery__dot';
+      dot.setAttribute('aria-label', `Go to image ${index + 1}`);
+      dot.addEventListener('click', () => setActiveImage(index));
+      dotsContainer.appendChild(dot);
+    });
+  } else if (dotsContainer) {
+    dotsContainer.style.display = 'none';
+  }
+
+  let startX = 0;
+  mainMedia.addEventListener('touchstart', (event) => {
+    startX = event.changedTouches[0].clientX;
+  }, { passive: true });
+
+  mainMedia.addEventListener('touchend', (event) => {
+    const deltaX = event.changedTouches[0].clientX - startX;
+    if (Math.abs(deltaX) < 30) return;
+    setActiveImage(currentIndex + (deltaX < 0 ? 1 : -1));
+  }, { passive: true });
+
+  setActiveImage(0);
 }

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -76,6 +76,7 @@ function renderVariant(variant) {
   const mainImage = document.getElementById('system-variant-main-image');
   const gallery = document.getElementById('system-variant-gallery');
   const packageItems = document.getElementById('system-variant-package-items');
+  const galleryDots = document.getElementById('system-variant-gallery-dots');
   const addToCartButton = document.getElementById('spatc');
   const specifications = document.getElementById('longdescription');
 
@@ -117,6 +118,7 @@ function renderVariant(variant) {
 
   if (gallery) {
     gallery.innerHTML = '';
+    if (galleryDots) galleryDots.innerHTML = '';
     (variant.images || []).forEach((image, index) => {
       const button = document.createElement('button');
       button.type = 'button';
@@ -141,7 +143,29 @@ function renderVariant(variant) {
       }
 
       gallery.appendChild(button);
+
+      if (galleryDots && (variant.images || []).length > 1) {
+        const dot = document.createElement('button');
+        dot.type = 'button';
+        dot.className = 'single-product-gallery__dot';
+        dot.setAttribute('aria-label', `Go to image ${index + 1}`);
+        dot.addEventListener('click', () => {
+          if (mainImage) {
+            mainImage.src = image.url;
+            mainImage.alt = image.alt_text || variant.title;
+          }
+          galleryDots.querySelectorAll('button').forEach((node, dotIndex) => node.classList.toggle('is-active', dotIndex === index));
+        });
+        if (index === 0) {
+          dot.classList.add('is-active');
+        }
+        galleryDots.appendChild(dot);
+      }
     });
+
+    if (galleryDots && (variant.images || []).length <= 1) {
+      galleryDots.innerHTML = '';
+    }
 
     if (!(variant.images || []).length && mainImage) {
       mainImage.removeAttribute('src');
@@ -199,6 +223,39 @@ export function initSystemVariants() {
 
   renderVariant(selectedVariant);
   syncActiveState();
+
+  const mainMedia = document.querySelector('.single-product-gallery__main');
+  let touchStartX = 0;
+
+  if (mainMedia) {
+    mainMedia.addEventListener('touchstart', (event) => {
+      touchStartX = event.changedTouches[0].clientX;
+    }, { passive: true });
+
+    mainMedia.addEventListener('touchend', (event) => {
+      const images = selectedVariant && selectedVariant.images ? selectedVariant.images : [];
+      if (images.length <= 1) {
+        return;
+      }
+      const deltaX = event.changedTouches[0].clientX - touchStartX;
+      if (Math.abs(deltaX) < 30) {
+        return;
+      }
+
+      const mainImage = document.getElementById('system-variant-main-image');
+      const currentIndex = Math.max(0, images.findIndex((image) => image.url === (mainImage ? mainImage.src : '')));
+      const nextIndex = (currentIndex + (deltaX < 0 ? 1 : -1) + images.length) % images.length;
+      const nextImage = images[nextIndex];
+
+      if (mainImage && nextImage) {
+        mainImage.src = nextImage.url;
+        mainImage.alt = nextImage.alt_text || (selectedVariant ? selectedVariant.title : '');
+      }
+
+      const dots = document.querySelectorAll('#system-variant-gallery-dots .single-product-gallery__dot');
+      dots.forEach((dot, dotIndex) => dot.classList.toggle('is-active', dotIndex === nextIndex));
+    }, { passive: true });
+  }
 
   selector.addEventListener('click', (event) => {
     const targetButton = event.target.closest('.system-variant-option');

--- a/static/doobarashop/sass/layout/_header.scss
+++ b/static/doobarashop/sass/layout/_header.scss
@@ -40,6 +40,12 @@ header {
             background: #1ebe5d;
         }
 
+        .nav-right .whatsapp-btn {
+            padding: 6px 10px;
+            font-size: 0.82rem;
+            border-radius: 8px;
+        }
+
         .nav-links {
             display: flex;
             align-items: center;
@@ -149,21 +155,21 @@ header {
 
 @media (max-width: 720px) {
     .nav {
-        padding-inline: 1rem;
+        padding: 0.45rem 0.75rem;
         // Mobile menu button styles
         #mobile-menu-btn {
             display: flex;
             justify-content: center;
             align-items: center;
             flex-direction: column;
-            width: 60px; /* Set a fixed width */
-            height: 60px; /* Set a fixed height */
+            width: 46px; /* Compact mobile control */
+            height: 46px; /* Set a fixed height */
             cursor: pointer; /* Make the entire div clickable */
             background: none; /* Optional: Add a background if needed */
             border: none; /* Remove any default border styling */
 
             i {
-                font-size: 1.8rem; /* Icon size */
+                font-size: 1.35rem; /* Icon size */
                 color: var.$identity-color; /* Icon color */
                 pointer-events: none; /* Disable pointer events on child elements */
             }
@@ -171,14 +177,19 @@ header {
             p {
                 margin: 0;
                 padding: 0;
-                font-size: 1rem;
+                font-size: 0.72rem;
                 color: var.$identity-color;
                 pointer-events: none; /* Disable pointer events on child elements */
             }
         }
 
         .nav-logo {
-            width: 30% !important;
+            width: 34% !important;
+
+            img {
+                max-height: 34px;
+                width: auto;
+            }
         }
 
         .nav-links {
@@ -189,10 +200,15 @@ header {
             display: none !important;
         }
         .nav-cart {
-            margin-right: .7rem;
+            margin-right: .2rem;
+            min-width: 2.25rem;
 
-            .carttotal {
-                font-size: 0.68rem;
+            a {
+                font-size: 1.25em;
+            }
+
+             .carttotal {
+                font-size: 0.62rem;
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Make mobile product and system pages more compact and conversion-focused so the tier selector and buy controls appear earlier for ad traffic.
- Reduce header vertical weight on small screens while keeping desktop header behavior unchanged.
- Replace bulky mobile thumbnail rail with swipeable main image + pagination dots to save vertical space.
- Add an explicit WhatsApp help CTA immediately after Add to Cart to improve support conversions.

### Description
- Compacted mobile header spacing and control sizes in `static/doobarashop/sass/layout/_header.scss` (mobile-only changes, desktop preserved). 
- Moved short/hero description earlier and added gallery dot containers and a WhatsApp help CTA in `shop/templates/shop/single_product.html`. 
- Replaced mobile thumbnail row with hidden thumbs + pagination dots and added styles in `shop/sass/pages/_single-product.scss` to tighten gallery sizing and style the WhatsApp CTA. 
- Implemented swipe + dots behavior for normal product gallery in `static/doobarashop/js/features/productGallery.js`. 
- Extended system-variant gallery logic to render dots per-variant, sync active state, and support swipe navigation in `static/doobarashop/js/features/systemVariants.js`. 
- Reused and extended the existing WhatsApp helper to prefill a message including page title and URL for both header and new CTA in `static/doobarashop/js/features/footerAndWhatsapp.js`. 
- All styling changes were added to SCSS files only; `style.css` was not modified.

### Testing
- Ran a quick static runtime check with `python manage.py check`, which could not complete because the local environment is missing `SECRET_KEY` (Django check failed). 
- No automated frontend tests were present or executed in this environment, and no database migrations were required. 
- Verified code paths locally by inspecting templates/JS/SCSS changes and ensured JS feature modules include safe DOM guards so behavior only runs on pages with expected elements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06da8f6e908324aef343824e9e2b7c)