### PR TITLE
Show system tier item counts on single product options

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -668,6 +668,13 @@
     font-size: 0.95rem;
 }
 
+.system-variant-option__items-count {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.82rem;
+    color: #6b7280;
+}
+
 .system-variant-package-items {
     list-style: none;
     padding: 0;

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -58,6 +58,9 @@
                                 <span class="system-variant-option__price">
                                     $ {% if variant.sale_price %}{{ variant.sale_price|floatformat:2 }}{% else %}{{ variant.price|floatformat:2 }}{% endif %}
                                 </span>
+                                <span class="system-variant-option__items-count">
+                                    {{ variant.package_items|length }} items
+                                </span>
                             </button>
                         {% endfor %}
                     </div>


### PR DESCRIPTION
### Motivation
- Provide an at-a-glance included-items count on each system variant option (Basic / Advanced / Pro) to help customers compare tiers quickly.
- Keep the count authoritative by deriving it from server-managed data using `variant.package_items|length` so the UI always reflects actual tier contents.

### Description
- Add an item-count label inside each `.system-variant-option` button in `shop/templates/shop/single_product.html` using `{{ variant.package_items|length }}`.
- Add `.system-variant-option__items-count` styling to `shop/sass/pages/_single-product.scss` to control spacing, font-size, and muted color for the count label.
- Preserve existing markup, pricing display, and analytics attributes so existing variant selection and add-to-cart behavior remain unchanged.

### Testing
- Ran `python manage.py check` in the environment, which did not complete successfully because the `SECRET_KEY` environment variable is not set (automated check failed for that reason).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1099ed243883249c97668fe3ce31de)