### PR TITLE
Add single-product image lightbox with zoom trigger and keyboard/swipe navigation

### DIFF
--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -718,3 +718,113 @@
         padding: 10px 8px;
     }
 }
+
+.single-product-gallery__main {
+    position: relative;
+}
+
+.single-product-gallery__zoom-btn {
+    position: absolute;
+    left: 14px;
+    bottom: 14px;
+    width: 38px;
+    height: 38px;
+    border: 0;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.88);
+    color: #111827;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.2);
+    cursor: pointer;
+    z-index: 2;
+}
+
+.single-product-gallery__zoom-btn:focus-visible {
+    outline: 2px solid var.$ui-primary;
+    outline-offset: 2px;
+}
+
+.single-product-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(15, 23, 42, 0.82);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 22px;
+}
+
+.single-product-lightbox[hidden] {
+    display: none;
+}
+
+.single-product-lightbox__stage {
+    max-width: 92vw;
+    max-height: 82vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.single-product-lightbox__stage img {
+    max-width: 92vw;
+    max-height: 82vh;
+    object-fit: contain;
+}
+
+.single-product-lightbox__close,
+.single-product-lightbox__nav {
+    position: absolute;
+    border: 0;
+    color: #fff;
+    background: rgba(15, 23, 42, 0.55);
+    cursor: pointer;
+}
+
+.single-product-lightbox__close {
+    top: 18px;
+    right: 18px;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    font-size: 1.8rem;
+    line-height: 1;
+}
+
+.single-product-lightbox__nav {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 48px;
+    height: 48px;
+    border-radius: 999px;
+    font-size: 1.6rem;
+}
+
+.single-product-lightbox__nav--prev { left: 14px; }
+.single-product-lightbox__nav--next { right: 14px; }
+
+body.is-lightbox-open {
+    overflow: hidden;
+}
+
+@media (max-width: 640px) {
+    .single-product-gallery__zoom-btn {
+        left: 10px;
+        bottom: 10px;
+        width: 40px;
+        height: 40px;
+    }
+
+    .single-product-lightbox__close {
+        top: 10px;
+        right: 10px;
+    }
+
+    .single-product-lightbox__nav {
+        width: 44px;
+        height: 44px;
+    }
+}

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -724,6 +724,7 @@
 }
 
 .single-product-gallery__zoom-btn {
+    display: none;
     position: absolute;
     left: 14px;
     bottom: 14px;
@@ -733,7 +734,6 @@
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.88);
     color: #111827;
-    display: inline-flex;
     align-items: center;
     justify-content: center;
     box-shadow: 0 6px 14px rgba(15, 23, 42, 0.2);
@@ -812,6 +812,7 @@ body.is-lightbox-open {
 
 @media (max-width: 640px) {
     .single-product-gallery__zoom-btn {
+        display: inline-flex;
         left: 10px;
         bottom: 10px;
         width: 40px;

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -40,8 +40,22 @@
                              height="1000"
                              loading="eager"
                              fetchpriority="high">
+                                            <button type="button"
+                                class="single-product-gallery__zoom-btn"
+                                data-product-lightbox-open
+                                aria-label="Open image gallery">
+                            <i class="fas fa-search-plus" aria-hidden="true"></i>
+                        </button>
                     </div>
                     <div id="system-variant-gallery" class="single-product-gallery__thumbs"></div>
+                    <div class="single-product-lightbox" data-product-lightbox role="dialog" aria-modal="true" hidden>
+                        <button type="button" class="single-product-lightbox__close" data-product-lightbox-close aria-label="Close image gallery">&times;</button>
+                        <button type="button" class="single-product-lightbox__nav single-product-lightbox__nav--prev" data-product-lightbox-prev aria-label="Previous image">&#10094;</button>
+                        <div class="single-product-lightbox__stage">
+                            <img src="" alt="" data-product-lightbox-image>
+                        </div>
+                        <button type="button" class="single-product-lightbox__nav single-product-lightbox__nav--next" data-product-lightbox-next aria-label="Next image">&#10095;</button>
+                    </div>
                 </div>
 
                 <div class="single-product-info">
@@ -150,6 +164,12 @@
                         {% else %}
                             <div class="single-product-gallery__empty" id="spi" aria-label="{{ product.title }} image unavailable"></div>
                         {% endif %}
+                                            <button type="button"
+                                class="single-product-gallery__zoom-btn"
+                                data-product-lightbox-open
+                                aria-label="Open image gallery">
+                            <i class="fas fa-search-plus" aria-hidden="true"></i>
+                        </button>
                     </div>
 
                     <div class="single-product-gallery__thumbs">
@@ -161,6 +181,14 @@
                                         aria-label="View image {{ forloop.counter }} of {{ product.all_images|length }}">
                                 </button>
                         {% endfor %}
+                    </div>
+                    <div class="single-product-lightbox" data-product-lightbox role="dialog" aria-modal="true" hidden>
+                        <button type="button" class="single-product-lightbox__close" data-product-lightbox-close aria-label="Close image gallery">&times;</button>
+                        <button type="button" class="single-product-lightbox__nav single-product-lightbox__nav--prev" data-product-lightbox-prev aria-label="Previous image">&#10094;</button>
+                        <div class="single-product-lightbox__stage">
+                            <img src="" alt="" data-product-lightbox-image>
+                        </div>
+                        <button type="button" class="single-product-lightbox__nav single-product-lightbox__nav--next" data-product-lightbox-next aria-label="Next image">&#10095;</button>
                     </div>
                 </div>
 

--- a/static/doobarashop/js/bootstrap.js
+++ b/static/doobarashop/js/bootstrap.js
@@ -6,6 +6,7 @@ import { initFooterAndWhatsapp } from './features/footerAndWhatsapp.js';
 import { initMobileMenu } from './features/mobileMenu.js';
 import { initMobileSearch } from './features/mobileSearch.js';
 import { initProductGallery } from './features/productGallery.js?v=20260516-gallery-dots';
+import { initProductLightbox } from './features/productLightbox.js?v=20260523-lightbox';
 import { initShopTabs } from './features/shopTabs.js';
 import { initProductVariants } from './features/productVariants.js';
 import { initSystemVariants } from './features/systemVariants.js?v=20260516-gallery-dots';
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initProductVariants();
   initSystemVariants();
   initProductGallery();
+  initProductLightbox();
   initCartActions();
   initCheckoutTotals();
   initAddressPopup();

--- a/static/doobarashop/js/features/productLightbox.js
+++ b/static/doobarashop/js/features/productLightbox.js
@@ -23,6 +23,7 @@ export function initProductLightbox() {
   }
 
   const body = document.body;
+  const mobileQuery = window.matchMedia('(max-width: 640px)');
   let lastFocused = null;
   let currentIndex = 0;
   let touchStartX = null;
@@ -79,6 +80,11 @@ export function initProductLightbox() {
   }
 
   function open() {
+    // Keep the lightbox mobile-only to match the requested UX scope.
+    if (!mobileQuery.matches) {
+      return;
+    }
+
     const images = getImages();
     if (!images.length) {
       return;
@@ -109,6 +115,13 @@ export function initProductLightbox() {
   }
 
   openButton.addEventListener('click', open);
+
+  mobileQuery.addEventListener('change', (event) => {
+    // If viewport exits mobile size while open, force-close and restore scrolling/focus state.
+    if (!event.matches) {
+      close();
+    }
+  });
   closeButton.addEventListener('click', close);
   prevButton.addEventListener('click', () => move(-1));
   nextButton.addEventListener('click', () => move(1));

--- a/static/doobarashop/js/features/productLightbox.js
+++ b/static/doobarashop/js/features/productLightbox.js
@@ -1,0 +1,164 @@
+export function initProductLightbox() {
+  const gallery = document.querySelector('.single-product-gallery');
+  if (!gallery) {
+    return;
+  }
+
+  const mainImageWrap = gallery.querySelector('.single-product-gallery__main');
+  const mainImage = mainImageWrap ? mainImageWrap.querySelector('img') : null;
+  const openButton = gallery.querySelector('[data-product-lightbox-open]');
+  const lightbox = gallery.querySelector('[data-product-lightbox]');
+
+  if (!mainImageWrap || !mainImage || !openButton || !lightbox) {
+    return;
+  }
+
+  const closeButton = lightbox.querySelector('[data-product-lightbox-close]');
+  const prevButton = lightbox.querySelector('[data-product-lightbox-prev]');
+  const nextButton = lightbox.querySelector('[data-product-lightbox-next]');
+  const lightboxImage = lightbox.querySelector('[data-product-lightbox-image]');
+
+  if (!closeButton || !prevButton || !nextButton || !lightboxImage) {
+    return;
+  }
+
+  const body = document.body;
+  let lastFocused = null;
+  let currentIndex = 0;
+  let touchStartX = null;
+  let touchStartY = null;
+
+  function getImages() {
+    // Read fresh image data every time so variant-driven galleries remain in sync.
+    const dots = Array.from(gallery.querySelectorAll('.single-product-thumb'));
+    const images = dots
+      .map((dot) => ({
+        src: dot.dataset.imageSrc || '',
+        alt: dot.dataset.imageAlt || mainImage.alt || '',
+      }))
+      .filter((item) => Boolean(item.src));
+
+    if (!images.length && mainImage.src) {
+      images.push({ src: mainImage.src, alt: mainImage.alt || '' });
+    }
+
+    return images;
+  }
+
+  function findCurrentIndex(images) {
+    const currentSrc = mainImage.currentSrc || mainImage.src;
+    const found = images.findIndex((item) => item.src === currentSrc);
+    return found >= 0 ? found : 0;
+  }
+
+  function render() {
+    const images = getImages();
+    if (!images.length) {
+      return;
+    }
+
+    const active = images[currentIndex] || images[0];
+    lightboxImage.src = active.src;
+    lightboxImage.alt = active.alt || mainImage.alt || '';
+
+    const hasManyImages = images.length > 1;
+    prevButton.hidden = !hasManyImages;
+    nextButton.hidden = !hasManyImages;
+    prevButton.disabled = !hasManyImages;
+    nextButton.disabled = !hasManyImages;
+  }
+
+  function move(step) {
+    const images = getImages();
+    if (images.length <= 1) {
+      return;
+    }
+
+    currentIndex = (currentIndex + step + images.length) % images.length;
+    render();
+  }
+
+  function open() {
+    const images = getImages();
+    if (!images.length) {
+      return;
+    }
+
+    lastFocused = document.activeElement;
+    currentIndex = findCurrentIndex(images);
+    render();
+
+    lightbox.hidden = false;
+    body.classList.add('is-lightbox-open');
+    closeButton.focus();
+  }
+
+  function close() {
+    if (lightbox.hidden) {
+      return;
+    }
+
+    lightbox.hidden = true;
+    body.classList.remove('is-lightbox-open');
+
+    if (lastFocused && typeof lastFocused.focus === 'function') {
+      lastFocused.focus();
+    } else {
+      openButton.focus();
+    }
+  }
+
+  openButton.addEventListener('click', open);
+  closeButton.addEventListener('click', close);
+  prevButton.addEventListener('click', () => move(-1));
+  nextButton.addEventListener('click', () => move(1));
+
+  lightbox.addEventListener('click', (event) => {
+    if (event.target === lightbox) {
+      close();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (lightbox.hidden) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      move(-1);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      move(1);
+    }
+  });
+
+  lightbox.addEventListener('touchstart', (event) => {
+    if (!event.touches.length) {
+      return;
+    }
+
+    touchStartX = event.touches[0].clientX;
+    touchStartY = event.touches[0].clientY;
+  }, { passive: true });
+
+  lightbox.addEventListener('touchend', (event) => {
+    if (touchStartX === null || touchStartY === null || !event.changedTouches.length) {
+      return;
+    }
+
+    const distanceX = event.changedTouches[0].clientX - touchStartX;
+    const distanceY = event.changedTouches[0].clientY - touchStartY;
+    touchStartX = null;
+    touchStartY = null;
+
+    if (Math.abs(distanceX) < 40 || Math.abs(distanceY) > Math.abs(distanceX)) {
+      return;
+    }
+
+    move(distanceX < 0 ? 1 : -1);
+  }, { passive: true });
+}


### PR DESCRIPTION
### Motivation
- Provide a full-screen, accessible lightbox for product images from the single product page so customers can view larger images and navigate the gallery without changing existing gallery behavior.
- Reuse the gallery data already rendered in the template and keep the change scoped and non-invasive to models or existing `productGallery` logic.

### Description
- Updated the single product template by adding a bottom-left zoom button and a lightbox dialog markup to both normal and system product gallery branches (`shop/templates/shop/single_product.html`).
- Added a new feature module `initProductLightbox` in `static/doobarashop/js/features/productLightbox.js` that reads image URLs/alt from existing `.single-product-thumb` dataset values (with main-image fallback), opens at the currently selected image, supports Escape/ArrowLeft/ArrowRight keyboard navigation, overlay click and close button, disables prev/next for single-image galleries, restores focus and body scroll state, and supports swipe left/right on mobile.
- Wired the new module into the site's JS bootstrap by importing and calling `initProductLightbox()` from `static/doobarashop/js/bootstrap.js`.
- Added scoped SCSS for the zoom button, lightbox backdrop/stage, nav/close controls, and mobile adjustments in `shop/sass/pages/_single-product.scss`, and confirmed `style.css` was not modified.

### Testing
- Ran `python manage.py check` in this environment which failed due to a missing environment variable (`SECRET_KEY`), so the Django system checks could not be completed here (failure unrelated to the changes made).
- No other automated tests were executed in this environment; the JS/SCSS changes were added and committed (`git commit` completed successfully) but runtime verification should be performed in a development environment with proper settings to confirm UI/keyboard/swipe behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b6727454832496538df844dd603e)