### PR TITLE
Add support for full-width “long” product images and variant-driven switching

### DIFF
--- a/shop/admin.py
+++ b/shop/admin.py
@@ -24,7 +24,7 @@ from .models import (
 class ProductImageInline(admin.TabularInline):
     model = ProductImage
     extra = 1
-    fields = ("image", "image_preview", "alt_text", "thumbnail")
+    fields = ("image", "image_preview", "alt_text", "thumbnail", "long_image")
     readonly_fields = ("image_preview",)
 
     def image_preview(self, obj):
@@ -103,7 +103,7 @@ class SystemVariantFeatureAssignmentInline(admin.TabularInline):
 class ProductVariantImageInline(admin.TabularInline):
     model = ProductVariantImage
     extra = 1
-    fields = ("image", "image_preview", "alt_text", "thumbnail")
+    fields = ("image", "image_preview", "alt_text", "thumbnail", "long_image")
     readonly_fields = ("image_preview",)
 
     def image_preview(self, obj):
@@ -353,7 +353,7 @@ class NormalProductVariantAdmin(ImportExportActionModelAdmin):
         (
             "Content",
             {
-                "fields": ("short_description", "image"),
+                "fields": ("short_description", "image", "long_image"),
             },
         ),
     )
@@ -361,17 +361,17 @@ class NormalProductVariantAdmin(ImportExportActionModelAdmin):
 
 @admin.register(ProductImage)
 class ProductImageAdmin(ImportExportActionModelAdmin):
-    list_display = ("product", "alt_text", "thumbnail")
+    list_display = ("product", "alt_text", "thumbnail", "long_image")
     search_fields = ("product__name", "product__sku", "alt_text")
-    list_filter = ("thumbnail",)
+    list_filter = ("thumbnail", "long_image")
     ordering = ("product__name", "id")
 
 
 @admin.register(ProductVariantImage)
 class ProductVariantImageAdmin(ImportExportActionModelAdmin):
-    list_display = ("variant", "variant_product", "alt_text", "thumbnail")
+    list_display = ("variant", "variant_product", "alt_text", "thumbnail", "long_image")
     search_fields = ("variant__title", "variant__product__name", "alt_text")
-    list_filter = ("thumbnail",)
+    list_filter = ("thumbnail", "long_image")
     ordering = ("variant__product__name", "variant__title", "id")
 
     def variant_product(self, obj):

--- a/shop/migrations/0037_long_images.py
+++ b/shop/migrations/0037_long_images.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shop", "0036_variant_feature_assignments"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="normalproductvariant",
+            name="long_image",
+            field=models.ImageField(blank=True, null=True, upload_to="products/normal_variants/long_images/"),
+        ),
+        migrations.AddField(
+            model_name="productimage",
+            name="long_image",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="productvariantimage",
+            name="long_image",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/shop/modeling/serialize_helper.py
+++ b/shop/modeling/serialize_helper.py
@@ -20,8 +20,18 @@ def _get_all_images(product):
             "alt_text": image.alt_text or product.name,
             "thumbnail": image.thumbnail,
         }
-        for image in product.images.all()
+        for image in product.images.filter(long_image=False)
     ]
+
+
+def _get_long_image(product):
+    long_image = product.images.filter(long_image=True).first()
+    if not long_image:
+        return None
+    return {
+        "url": long_image.image.url,
+        "alt_text": long_image.alt_text or product.name,
+    }
 
 
 def _format_price_range(min_price, max_price):
@@ -91,6 +101,7 @@ def product_serialize(object, tag):
 
     image = _get_primary_image(object)
     all_images = _get_all_images(object)
+    long_image = _get_long_image(object)
     # Normal product variants are intentionally separate from system variants.
     active_normal_variants = [
         variant for variant in object.normal_variants.all() if variant.active
@@ -191,6 +202,7 @@ def product_serialize(object, tag):
             "main_image": image,
             "pallimages": all_images,
             "all_images": all_images,
+            "long_image": long_image,
             "system": object.is_system,
             "variant": object.variant,
             "pvariant": variant_options,

--- a/shop/models.py
+++ b/shop/models.py
@@ -333,6 +333,7 @@ class ProductImage(models.Model):
     # default is boolean 
     # if true the image is the main image for the product 
     thumbnail = models.BooleanField(default=False)  # True if this is a thumbnail image
+    long_image = models.BooleanField(default=False)
 
     class Meta:
         constraints = [
@@ -378,6 +379,7 @@ class NormalProductVariant(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     sale_price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
     image = models.ImageField(upload_to="products/normal_variants/images/", blank=True, null=True)
+    long_image = models.ImageField(upload_to="products/normal_variants/long_images/", blank=True, null=True)
     active = models.BooleanField(default=True, db_index=True)
     is_default = models.BooleanField(default=False)
     sort_order = models.PositiveSmallIntegerField(default=0)
@@ -559,6 +561,7 @@ class ProductVariantImage(models.Model):
     alt_text = models.CharField(max_length=255, blank=True)
     image = models.ImageField(upload_to='products/variants/images/')
     thumbnail = models.BooleanField(default=False)
+    long_image = models.BooleanField(default=False)
 
     class Meta:
         constraints = [

--- a/shop/sass/pages/_single-product.scss
+++ b/shop/sass/pages/_single-product.scss
@@ -829,3 +829,7 @@ body.is-lightbox-open {
         height: 44px;
     }
 }
+
+.single-product-long-image-card { margin: 24px 0; }
+.single-product-long-image-card img { width: 100%; height: auto; display: block; border-radius: 12px; }
+

--- a/shop/templates/shop/single_product.html
+++ b/shop/templates/shop/single_product.html
@@ -287,6 +287,13 @@
             {% endif %}
         {% endif %}
 
+        <div class="single-product-long-image-card" id="single-product-long-image-wrap" {% if not product.long_image and not product.system %}hidden{% endif %}>
+            <img id="single-product-long-image"
+                 src="{% if product.system and default_system_variant.long_image %}{{ default_system_variant.long_image.url }}{% elif default_normal_variant and default_normal_variant.long_image %}{{ default_normal_variant.long_image }}{% elif product.long_image %}{{ product.long_image.url }}{% endif %}"
+                 alt="{% if product.system and default_system_variant.long_image and default_system_variant.long_image.alt_text %}{{ default_system_variant.long_image.alt_text }}{% elif product.long_image and product.long_image.alt_text %}{{ product.long_image.alt_text }}{% else %}{{ product.title }}{% endif %}"
+                 loading="lazy">
+        </div>
+
         {% if product.pvideo %}
             <div class="single-product-video-card">
                 <div class="single-product-section-head">

--- a/shop/views.py
+++ b/shop/views.py
@@ -247,8 +247,12 @@ def single_product(request, locat=None, slug=None):
         thumb = _pick_thumbnail_from_prefetched(variant.images.all())
         images = [
             {"url": image.image.url, "alt_text": image.alt_text}
-            for image in variant.images.all()
+            for image in variant.images.all() if not image.long_image
         ]
+        variant_long_image = next(
+            ({"url": image.image.url, "alt_text": image.alt_text} for image in variant.images.all() if image.long_image),
+            None,
+        )
         package_items = []
         for package_item in variant.package_items.all():
             # package_items prefetches included product images; keep thumbnail selection in-memory.
@@ -283,6 +287,7 @@ def single_product(request, locat=None, slug=None):
             "cart_cta_label": variant_inventory["cart_cta_label"],
             "thumbnail": thumb.image.url if thumb else None,
             "images": images,
+            "long_image": variant_long_image,
             "package_items": package_items,
             "is_default": variant.is_default,
             "sort_order": variant.sort_order,
@@ -320,6 +325,7 @@ def single_product(request, locat=None, slug=None):
             "price": float(variant.price),
             "sale_price": float(variant.sale_price) if variant.sale_price else None,
             "image": variant.image.url if variant.image else None,
+            "long_image": variant.long_image.url if variant.long_image else None,
             "is_default": variant.is_default,
             "sort_order": variant.sort_order,
             # Variant-level features are applied as add/remove overrides in JS.

--- a/static/doobarashop/js/features/productVariants.js
+++ b/static/doobarashop/js/features/productVariants.js
@@ -8,6 +8,8 @@ export function initProductVariants() {
   const shortDescription = document.getElementById('normal-variant-short-description');
   const productImage = document.getElementById('spi');
   const defaultFeatureCardsElement = document.getElementById('default-feature-cards-data');
+  const longImageWrap = document.getElementById('single-product-long-image-wrap');
+  const longImage = document.getElementById('single-product-long-image');
 
   if (!variantDataElement || !selector || !addToCartButton || !productPrice) {
     return;
@@ -112,6 +114,16 @@ export function initProductVariants() {
     if (productImage && selectedVariant.image) {
       productImage.src = selectedVariant.image;
       productImage.alt = selectedVariant.title || productImage.alt;
+    }
+
+    if (longImageWrap && longImage) {
+      if (selectedVariant.long_image) {
+        longImage.src = selectedVariant.long_image;
+        longImage.alt = selectedVariant.title || longImage.alt;
+        longImageWrap.hidden = false;
+      } else {
+        longImageWrap.hidden = true;
+      }
     }
   }
 

--- a/static/doobarashop/js/features/systemVariants.js
+++ b/static/doobarashop/js/features/systemVariants.js
@@ -81,6 +81,8 @@ function renderVariant(variant) {
   const featureSection = document.getElementById('single-product-feature-card');
   const featureGrid = document.getElementById('single-product-benefit-grid');
   const defaultFeatureCardsElement = document.getElementById('default-feature-cards-data');
+  const longImageWrap = document.getElementById('single-product-long-image-wrap');
+  const longImage = document.getElementById('single-product-long-image');
   let defaultFeatureCards = [];
   try {
     defaultFeatureCards = defaultFeatureCardsElement ? JSON.parse(defaultFeatureCardsElement.textContent || '[]') : [];
@@ -233,6 +235,16 @@ function renderVariant(variant) {
       featureGrid.appendChild(article);
     });
     featureSection.hidden = !cards.length;
+  }
+
+  if (longImageWrap && longImage) {
+    if (variant.long_image && variant.long_image.url) {
+      longImage.src = variant.long_image.url;
+      longImage.alt = variant.long_image.alt_text || variant.title || longImage.alt;
+      longImageWrap.hidden = false;
+    } else {
+      longImageWrap.hidden = true;
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- Add a full-width image area on the single product page that displays an image marked as a product-level or variant-level “long image” before the product video, and keep that image out of the main gallery thumbnails.
- Allow editors to mark images as `long_image` in the admin (checkbox next to `thumbnail`) and let normal variants upload their own `long_image` so the long image can change with variant selection.
- Preserve the existing separation between system variants and normal variants while ensuring variant switching updates the long image when present.

### Description
- Models: added `long_image` boolean to `ProductImage` and `ProductVariantImage`, and added `long_image` `ImageField` to `NormalProductVariant` (file: `shop/models.py`).
- Admin: exposed `long_image` in `ProductImageInline` and `ProductVariantImageInline`, added `long_image` to `NormalProductVariant` content fieldset, and added list/filter columns (file: `shop/admin.py`).
- Serialization / views: excluded `long_image`-flagged images from the gallery payload, added `long_image` payloads for product/variant data, and included `long_image` in the `single_product` view payloads for both system and normal variants (files: `shop/modeling/serialize_helper.py`, `shop/views.py`).
- Template & frontend: inserted a full-width long-image block before the product video in `shop/templates/shop/single_product.html`, and updated JS variant switchers (`static/doobarashop/js/features/productVariants.js` and `systemVariants.js`) to show/hide and swap the long image when the active variant changes.
- Styling: added SCSS for the long-image card in `shop/sass/pages/_single-product.scss` and kept styling changes out of `style.css`.
- Migration: added `shop/migrations/0037_long_images.py` to add the new fields to the DB schema.

### Testing
- `python -m py_compile shop/models.py shop/admin.py shop/views.py` succeeded and confirmed the edited Python files are syntactically valid.
- Running `python manage.py makemigrations shop` failed in this environment with `django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet`, so the migration was created manually as `0037_long_images.py` and included in the PR; database migration application should be run in a proper Django runtime (local/dev) before deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c2284a608324bb051a6879dedb1d)