### PR TITLE
Allow guest checkout orders

### DIFF
--- a/cart/templates/cart/checkout.html
+++ b/cart/templates/cart/checkout.html
@@ -75,7 +75,11 @@ My Cart
                     <form id="shipping-details-id" class="checkout-form" action="{% url 'placeorder' %}" method="POST">
                         {% csrf_token %}
 
-                        {% if address_id > 0 %}
+                        {% if not user.is_authenticated %}
+                            <div class="checkout-new-address-form">
+                                {{form}}
+                            </div>
+                        {% elif address_id > 0 %}
                             {% for item in loa %}
                                 {% if item.id == address_id %}
                                     <input type="hidden" name="current_address_id" value="{{item.id}}">

--- a/cart/views.py
+++ b/cart/views.py
@@ -72,14 +72,13 @@ def updatecart(request):
     return JsonResponse({"result":"done"}, status=201)
 
 @never_cache
-@login_required
 def checkout(request):
     # is instance object | (loc: modules.cartmanager)
     # create new cart manager instance 
     cm = CartManager(request)
     # is list | (loc: models)
     # all user address instances (list of address )
-    loa = request.user.myaddress.all()
+    loa = request.user.myaddress.all() if request.user.is_authenticated else []
     # is list of dict
     # create list of dict from objects
     sloa = [item.serialize() for item in loa]

--- a/promotions/services.py
+++ b/promotions/services.py
@@ -325,7 +325,7 @@ def record_coupon_usage(order, pricing):
 
         return CouponUsage.objects.create(
             coupon=locked_coupon,
-            user=order.user if order.user.is_authenticated else None,
+            user=order.user if order.user and order.user.is_authenticated else None,
             order=order,
             coupon_code_snapshot=pricing.get("coupon_code", locked_coupon.code),
             discount_amount=discount,

--- a/templates/doobarashop/order_notification_admin.html
+++ b/templates/doobarashop/order_notification_admin.html
@@ -30,9 +30,14 @@
 
                 <h2 style="margin:0 0 10px;font-size:16px;">Customer</h2>
                 <p style="margin:0 0 14px;font-size:14px;line-height:1.6;color:#374151;">
+                  {% if user %}
                   Name: {{ user.first_name }} {{ user.last_name }}<br />
                   Username: {{ user.username }}<br />
                   Email: {{ user.email }}
+                  {% else %}
+                  Guest customer<br />
+                  Email: {{ order.guest_email }}
+                  {% endif %}
                 </p>
 
                 {% if order.address %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -41,6 +41,7 @@ class OrdersAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "user",
+        "guest_email",
         "total",
         "status",
         "date",
@@ -56,6 +57,7 @@ class OrdersAdmin(admin.ModelAdmin):
         "user__first_name",
         "user__last_name",
         "user__email",
+        "guest_email",
         "address__phone_number",
         "address__name",
         "address__last_name",
@@ -79,6 +81,7 @@ class OrdersAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "user",
+                    "guest_email",
                     "address",
                 )
             },

--- a/users/forms.py
+++ b/users/forms.py
@@ -40,6 +40,7 @@ class CustomLoginForm(LoginForm):
 class Delivery_Information(ModelForm):
     
     notes = forms.CharField(max_length=200, required=False)
+    guest_email = forms.EmailField(label="Email", required=False)
 
 
     class Meta:

--- a/users/migrations/0018_guest_checkout.py
+++ b/users/migrations/0018_guest_checkout.py
@@ -1,0 +1,31 @@
+# Generated manually to support guest checkout orders.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('users', '0017_orders_coupon_code_orders_coupon_discount_amount'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='delivery_address_details',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='myaddress', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='orders',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='myorders', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='orders',
+            name='guest_email',
+            field=models.EmailField(blank=True, max_length=254),
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -32,7 +32,7 @@ class Delivery_Address_Details (models.Model):
     delivery_details = models.CharField(max_length=400, blank=True)
     # is object instance
     # user account 
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="myaddress")
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="myaddress", null=True, blank=True)
     # is boolean 
     # address default
     default = models.BooleanField(default=False)
@@ -60,7 +60,9 @@ class Delivery_Address_Details (models.Model):
 class Orders (models.Model):
     # is instance 
     # user who placed the order 
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="myorders")
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="myorders", null=True, blank=True)
+    # Guest checkout email snapshot for orders placed without a user account.
+    guest_email = models.EmailField(blank=True)
     # is instance
     # delivery address of user who placed the order 
     address = models.ForeignKey(Delivery_Address_Details, on_delete=models.SET_NULL, null=True)

--- a/users/modules/ordermanager.py
+++ b/users/modules/ordermanager.py
@@ -2,6 +2,7 @@ from ..models import *
 from ..forms import *
 from cart.modules.cartmanager import *
 from cart.modules.snippethelper import *
+from cart.modules.snippethelper import _load_session_cart_maps, _parse_cart_key
 from django.db import transaction
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
@@ -51,10 +52,53 @@ def _build_order_item_snapshot(cart_item):
     }
 
 
+def _build_session_order_item_snapshots(session_cart):
+    # Convert anonymous session cart rows into the same immutable order snapshots
+    # used for authenticated carts, without requiring a temporary user account.
+    product_map, variant_map, normal_variant_map = _load_session_cart_maps(session_cart)
+    snapshots = []
+    for key, data in session_cart.items():
+        quantity = int(data.get("quantity", 0) or 0)
+        if quantity <= 0:
+            continue
+
+        kind, object_id = _parse_cart_key(key)
+        if kind == "system_variant":
+            variant = variant_map.get(object_id)
+            if not variant:
+                continue
+            price = variant.sale_price if variant.sale_price else variant.price
+            snapshots.append({"product": variant.product, "quantity": quantity, "price": price, "product_name": variant.title})
+        elif kind == "normal_variant":
+            normal_variant = normal_variant_map.get(object_id)
+            if not normal_variant:
+                continue
+            price = normal_variant.sale_price if normal_variant.sale_price else normal_variant.price
+            snapshots.append({
+                "product": normal_variant.product,
+                "quantity": quantity,
+                "price": price,
+                "product_name": f"{normal_variant.product.name} - {normal_variant.title}",
+            })
+        else:
+            product = product_map.get(object_id)
+            if not product:
+                continue
+            price = product.sale_price if product.sale_price else product.price
+            snapshots.append({"product": product, "quantity": quantity, "price": price, "product_name": product.name})
+    return snapshots
+
+
 def createorder(request, form, new):
-    user = request.user
-    cart_items = list(user.mycart.items.select_related("product", "variant", "normal_variant"))
-    if not cart_items:
+    user = request.user if request.user.is_authenticated else None
+    if user:
+        cart_items = list(user.mycart.items.select_related("product", "variant", "normal_variant"))
+        item_snapshots = [_build_order_item_snapshot(item) for item in cart_items]
+    else:
+        cart_items = []
+        item_snapshots = _build_session_order_item_snapshots(request.session.get("cart", {}))
+
+    if not item_snapshots:
         return (False, _build_checkout_error_form("Your cart is empty. Please add products before placing an order."))
 
     # result = create_new_address(request, form)
@@ -66,16 +110,20 @@ def createorder(request, form, new):
             state = False
             # is list
             # list of user saved delivery addresses
-            allad = user.myaddress.all()
+            allad = user.myaddress.all() if user else []
            
-            if len(allad) == 0:
+            if user and len(allad) == 0:
                 state=True
             
             # record instance
             # create a new instance deliver address data
             note = form.cleaned_data.get('notes')
+            guest_email = form.cleaned_data.get('guest_email', '').strip()
+            if not user and not guest_email:
+                form.add_error('guest_email', 'Email is required for guest checkout.')
+                return (False, form)
             form.instance.user = user
-            form.instance.default = state
+            form.instance.default = state if user else False
             delivery =form.save()        
 
         else:
@@ -86,6 +134,7 @@ def createorder(request, form, new):
         # current saved in data address
         id = int(form['current_address_id'])
         note = form.get('ordernote', '').strip()
+        guest_email = ''
         # Security: lock address selection to the authenticated user so posted
         # IDs cannot attach someone else's saved address to this order.
         try:
@@ -120,7 +169,7 @@ def createorder(request, form, new):
     with transaction.atomic():
         if coupon_pricing["coupon_valid"]:
             # Re-check limits under row lock so concurrent checkouts cannot over-redeem capped coupons.
-            usage_ok, usage_error, locked_coupon = check_usage_limits_atomic(coupon_pricing["coupon"], user)
+            usage_ok, usage_error, locked_coupon = check_usage_limits_atomic(coupon_pricing["coupon"], request.user)
             if not usage_ok:
                 return (False, _build_checkout_error_form(usage_error))
             coupon_pricing["coupon"] = locked_coupon
@@ -129,6 +178,7 @@ def createorder(request, form, new):
         # create an new order object model
         order = Orders.objects.create(
             user=user,
+            guest_email=guest_email,
             address=delivery,
             total=total,
             note=note,
@@ -139,8 +189,6 @@ def createorder(request, form, new):
             coupon_discount_amount=coupon_pricing["coupon_discount"] if coupon_pricing["coupon_valid"] else 0,
         )
 
-        # NEW: Convert each cart row into a variant-aware immutable purchase snapshot.
-        item_snapshots = [_build_order_item_snapshot(item) for item in cart_items]
         Item_Order.objects.bulk_create(
             [
                 Item_Order(
@@ -153,7 +201,11 @@ def createorder(request, form, new):
                 for snapshot in item_snapshots
             ]
         )
-        user.mycart.items.filter(id__in=[item.id for item in cart_items]).delete()
+        if user:
+            user.mycart.items.filter(id__in=[item.id for item in cart_items]).delete()
+        else:
+            request.session["cart"] = {}
+            request.session.save()
         if coupon_pricing["coupon_valid"]:
             # Snapshot and usage tracking happen only after a successful committed order.
             snapshot_coupon_to_order(order, coupon_pricing)
@@ -216,11 +268,11 @@ def send_order_confirmation_email_to_user_and_admin(order):
         if not order:
             return
 
-    customer_email = order.user.email
+    customer_email = order.user.email if order.user else order.guest_email
     if not customer_email:
         return
 
-    customer_name = order.user.first_name or (order.address.name if order.address else "Customer")
+    customer_name = (order.user.first_name if order.user else "") or (order.address.name if order.address else "Customer")
     items = [
         {
             "product_name": item.product_name,

--- a/users/views.py
+++ b/users/views.py
@@ -43,7 +43,6 @@ def myaccount(request):
 
 # caller: checkout
 # Create a new order instance
-@login_required
 @never_cache
 def placeorder(request):
     if request.method != "POST":
@@ -98,7 +97,7 @@ def placeorder(request):
         # If new form have invalid data return same form and chekout page to retry
         else:
             pricing = cart_pricing_breakdown(request)
-            loa = request.user.myaddress.all()
+            loa = request.user.myaddress.all() if request.user.is_authenticated else []
             sloa = [item.serialize() for item in loa]
             return render(request, "cart/checkout.html", {
                 "form": order[1],


### PR DESCRIPTION
### Motivation
- Let customers without accounts place orders using the session cart and provide an email for confirmations. 
- Preserve existing authenticated flows and order snapshots while avoiding data loss or incorrect coupon/account linking for guest checkouts. 

### Description
- Make `Delivery_Address_Details.user` and `Orders.user` optional and add `Orders.guest_email` to snapshot guest contact information (model updates and migration `users/migrations/0018_guest_checkout.py`).
- Accept guest email at checkout by adding `guest_email` to `Delivery_Information` form and validating it for guest checkouts (`users/forms.py`, `users/modules/ordermanager.py`).
- Remove login gating from checkout endpoints so unauthenticated visitors can access checkout and submit orders (`cart/views.py` and `users/views.py`).
- Convert session cart rows into immutable order item snapshots and create orders from them for guests, clearing the session cart after order creation (`users/modules/ordermanager.py` with `_build_session_order_item_snapshots` and guest-aware `createorder`).
- Include `guest_email` in admin views and order notification templates so admins can see guest contact info (`users/admin.py`, `templates/doobarashop/order_notification_admin.html`).
- Harden coupon usage recording and other paths to handle `order.user` being `None` safely (`promotions/services.py`).
- Small checkout template change to show the delivery form for guests directly (`cart/templates/cart/checkout.html`).

### Testing
- Compiled relevant modules with `python -m compileall users cart promotions` (succeeded).
- Ran `SECRET_KEY=dummy DEBUG=True python manage.py check` to validate app configuration in a minimal environment (succeeded).
- Ran `git diff --check` to ensure no whitespace/diff problems (succeeded).
- `python manage.py makemigrations --check --dry-run` and running the test suite (`SECRET_KEY=dummy DEBUG=True python manage.py test users cart promotions`) could not complete in this environment because no database `NAME`/`OPTIONS` is configured, so migrations/tests that require the DB were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35857798c883248dd47ea4e897aa3c)